### PR TITLE
fix: navigation between Patch/Extension/OSS modules

### DIFF
--- a/src/Views/MainWindow.axaml
+++ b/src/Views/MainWindow.axaml
@@ -1,9 +1,10 @@
-﻿<Window xmlns="https://github.com/avaloniaui"
+<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:GeneralUpdate.Tools.ViewModels"
         x:Class="GeneralUpdate.Tools.Views.MainWindow"
+        x:Name="MainWin"
         x:DataType="vm:MainWindowViewModel"
-        Title="GeneralUpdate Tools v12" Width="960" Height="640" MinWidth="780" MinHeight="540"
+        Title="GeneralUpdate Tools" Width="960" Height="640" MinWidth="780" MinHeight="540"
         WindowStartupLocation="CenterScreen">
     <DockPanel>
         <Border DockPanel.Dock="Left" Width="200" Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
@@ -11,15 +12,22 @@
                 <Border Grid.Row="0" Padding="18,20,18,12">
                     <TextBlock Text="GeneralUpdate Tools" FontSize="16" FontWeight="Bold"/>
                 </Border>
-                <ListBox Grid.Row="1" ItemsSource="{Binding NavItems}" Background="Transparent" BorderThickness="0">
-                    <ListBox.ItemTemplate>
+                <ItemsControl Grid.Row="1" ItemsSource="{Binding NavItems}">
+                    <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="vm:NavItem">
-                            <Border Padding="18,10" Background="Transparent" CornerRadius="0,8,8,0">
-                                <TextBlock Text="{Binding Title}" FontSize="13"/>
-                            </Border>
+                            <Button Content="{Binding Title}"
+                                    Command="{Binding ElementName=MainWin, Path=DataContext.NavigateCommand}"
+                                    CommandParameter="{Binding}"
+                                    HorizontalAlignment="Stretch"
+                                    HorizontalContentAlignment="Left"
+                                    Padding="18,10"
+                                    Margin="0"
+                                    Background="Transparent"
+                                    BorderThickness="0"
+                                    FontSize="13"/>
                         </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
             </Grid>
         </Border>
         <ContentControl Content="{Binding CurrentPage}"/>


### PR DESCRIPTION
﻿ListBox was only bound to ItemsSource with no SelectionChanged/SelectedItem/Command to trigger page switch.

Fix: ItemsControl + Button with ElementName binding to NavigateCommand.
