### PR TITLE
feat: multi-language support (zh-CN/en-US) and dark/light theme

### DIFF
--- a/src/Services/LocalizationService.cs
+++ b/src/Services/LocalizationService.cs
@@ -1,0 +1,190 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace GeneralUpdate.Tools.Services;
+
+/// <summary>
+/// Simple dictionary-based localization. Supports zh-CN and en-US.
+/// Usage: LocalizationService.Instance["Patch.Title"]
+/// </summary>
+public class LocalizationService : INotifyPropertyChanged
+{
+    public static LocalizationService Instance { get; } = new();
+
+    private string _locale = "zh-CN";
+
+    public string Locale
+    {
+        get => _locale;
+        set { if (_locale != value) { _locale = value; OnPropertyChanged(); OnPropertyChanged("Item"); } }
+    }
+
+    public string this[string key]
+    {
+        get
+        {
+            if (_strings.TryGetValue(_locale, out var langDict) && langDict.TryGetValue(key, out var val))
+                return val;
+            // Fallback to zh-CN
+            if (_locale != "zh-CN" && _strings.TryGetValue("zh-CN", out var fallback) && fallback.TryGetValue(key, out var fb))
+                return fb;
+            return key;
+        }
+    }
+
+    private readonly Dictionary<string, Dictionary<string, string>> _strings = new()
+    {
+        ["zh-CN"] = new()
+        {
+            ["App.Title"] = "GeneralUpdate Tools",
+            ["Nav.Patch"] = "补丁包",
+            ["Nav.Extension"] = "扩展包",
+            ["Nav.OSS"] = "OSS配置",
+            ["Patch.Title"] = "补丁包生成",
+            ["Patch.CorePaths"] = "核心路径",
+            ["Patch.OldDir"] = "旧版本目录",
+            ["Patch.NewDir"] = "新版本目录",
+            ["Patch.Select"] = "选择",
+            ["Patch.OldPlaceholder"] = "选择旧版本应用目录...",
+            ["Patch.NewPlaceholder"] = "选择新版本发布目录...",
+            ["Patch.PackageInfo"] = "包信息",
+            ["Patch.PackageName"] = "包名",
+            ["Patch.Version"] = "版本",
+            ["Patch.OutputDir"] = "输出目录",
+            ["Patch.OutputPlaceholder"] = "桌面 (默认)",
+            ["Patch.Build"] = "开始构建",
+            ["Patch.Ready"] = "就绪",
+            ["Patch.ValidateDirs"] = "请选择新旧版本目录",
+            ["Patch.Building"] = "正在生成差分补丁...",
+            ["Patch.Comparing"] = "对比目录差异 + 生成 BSDiff40 补丁...",
+            ["Patch.PatchDone"] = "补丁生成完成",
+            ["Patch.Packing"] = "打包: {0}",
+            ["Patch.Success"] = "成功: {0} ({1:F1} KB)",
+            ["Patch.Failed"] = "失败: {0}",
+            ["Patch.Error"] = "错误: {0}",
+            ["Patch.OldSelected"] = "旧版本: {0}",
+            ["Patch.NewSelected"] = "新版本: {0}",
+            ["Patch.TempDir"] = "临时目录: {0}",
+            ["Ext.Title"] = "扩展包生成",
+            ["Ext.BasicInfo"] = "基本信息",
+            ["Ext.Name"] = "名称",
+            ["Ext.Version"] = "版本",
+            ["Ext.Description"] = "描述",
+            ["Ext.DescPlaceholder"] = "扩展功能描述...",
+            ["Ext.Publisher"] = "发布者",
+            ["Ext.License"] = "许可证",
+            ["Ext.LicensePlaceholder"] = "MIT",
+            ["Ext.Paths"] = "路径",
+            ["Ext.ExtDir"] = "扩展目录",
+            ["Ext.ExportDir"] = "导出目录",
+            ["Ext.CustomProps"] = "自定义属性",
+            ["Ext.Key"] = "Key",
+            ["Ext.Value"] = "Value",
+            ["Ext.AddProp"] = "+ 添加",
+            ["Ext.Generate"] = "生成扩展包",
+            ["Ext.ValidateNameVer"] = "请填写扩展名称和版本",
+            ["Ext.ValidateDir"] = "请选择有效的扩展目录",
+            ["Ext.Building"] = "正在生成扩展包...",
+            ["Ext.Success"] = "成功: {0}",
+            ["Ext.Failed"] = "失败: {0}",
+            ["OSS.Title"] = "OSS 配置生成",
+            ["OSS.NewEntry"] = "新建条目",
+            ["OSS.PacketName"] = "包名",
+            ["OSS.Version"] = "版本",
+            ["OSS.Url"] = "URL",
+            ["OSS.SHA256"] = "SHA256",
+            ["OSS.ComputeHash"] = "计算",
+            ["OSS.AddToList"] = "添加到列表",
+            ["OSS.ConfigList"] = "配置列表",
+            ["OSS.Clear"] = "清空",
+            ["OSS.Export"] = "导出 JSON",
+            ["OSS.Added"] = "已添加",
+            ["OSS.Cleared"] = "已清空",
+            ["OSS.Exported"] = "导出: {0} 条",
+            ["OSS.HashResult"] = "SHA256: {0}",
+            ["Theme.Light"] = "浅色",
+            ["Theme.Dark"] = "深色",
+            ["Theme.Toggle"] = "切换主题",
+        },
+        ["en-US"] = new()
+        {
+            ["App.Title"] = "GeneralUpdate Tools",
+            ["Nav.Patch"] = "Patch",
+            ["Nav.Extension"] = "Extension",
+            ["Nav.OSS"] = "OSS Config",
+            ["Patch.Title"] = "Patch Package",
+            ["Patch.CorePaths"] = "Core Paths",
+            ["Patch.OldDir"] = "Old Directory",
+            ["Patch.NewDir"] = "New Directory",
+            ["Patch.Select"] = "Select",
+            ["Patch.OldPlaceholder"] = "Select old version directory...",
+            ["Patch.NewPlaceholder"] = "Select new version directory...",
+            ["Patch.PackageInfo"] = "Package Info",
+            ["Patch.PackageName"] = "Package Name",
+            ["Patch.Version"] = "Version",
+            ["Patch.OutputDir"] = "Output Directory",
+            ["Patch.OutputPlaceholder"] = "Desktop (default)",
+            ["Patch.Build"] = "Build",
+            ["Patch.Ready"] = "Ready",
+            ["Patch.ValidateDirs"] = "Please select both old and new directories",
+            ["Patch.Building"] = "Generating diff patch...",
+            ["Patch.Comparing"] = "Comparing directories + generating BSDiff40 patches...",
+            ["Patch.PatchDone"] = "Patch generation complete",
+            ["Patch.Packing"] = "Packing: {0}",
+            ["Patch.Success"] = "Success: {0} ({1:F1} KB)",
+            ["Patch.Failed"] = "Failed: {0}",
+            ["Patch.Error"] = "Error: {0}",
+            ["Patch.OldSelected"] = "Old version: {0}",
+            ["Patch.NewSelected"] = "New version: {0}",
+            ["Patch.TempDir"] = "Temp directory: {0}",
+            ["Ext.Title"] = "Extension Package",
+            ["Ext.BasicInfo"] = "Basic Info",
+            ["Ext.Name"] = "Name",
+            ["Ext.Version"] = "Version",
+            ["Ext.Description"] = "Description",
+            ["Ext.DescPlaceholder"] = "Extension description...",
+            ["Ext.Publisher"] = "Publisher",
+            ["Ext.License"] = "License",
+            ["Ext.LicensePlaceholder"] = "MIT",
+            ["Ext.Paths"] = "Paths",
+            ["Ext.ExtDir"] = "Extension Directory",
+            ["Ext.ExportDir"] = "Export Directory",
+            ["Ext.CustomProps"] = "Custom Properties",
+            ["Ext.Key"] = "Key",
+            ["Ext.Value"] = "Value",
+            ["Ext.AddProp"] = "+ Add",
+            ["Ext.Generate"] = "Generate Extension",
+            ["Ext.ValidateNameVer"] = "Please fill in extension name and version",
+            ["Ext.ValidateDir"] = "Please select a valid extension directory",
+            ["Ext.Building"] = "Generating extension package...",
+            ["Ext.Success"] = "Success: {0}",
+            ["Ext.Failed"] = "Failed: {0}",
+            ["OSS.Title"] = "OSS Config Generator",
+            ["OSS.NewEntry"] = "New Entry",
+            ["OSS.PacketName"] = "Package Name",
+            ["OSS.Version"] = "Version",
+            ["OSS.Url"] = "URL",
+            ["OSS.SHA256"] = "SHA256",
+            ["OSS.ComputeHash"] = "Compute",
+            ["OSS.AddToList"] = "Add to List",
+            ["OSS.ConfigList"] = "Config List",
+            ["OSS.Clear"] = "Clear",
+            ["OSS.Export"] = "Export JSON",
+            ["OSS.Added"] = "Added",
+            ["OSS.Cleared"] = "Cleared",
+            ["OSS.Exported"] = "Exported: {0} entries",
+            ["OSS.HashResult"] = "SHA256: {0}",
+            ["Theme.Light"] = "Light",
+            ["Theme.Dark"] = "Dark",
+            ["Theme.Toggle"] = "Toggle Theme",
+        }
+    };
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+    public string T(string key) => this[key];
+    public string T(string key, params object[] args) => string.Format(this[key], args);
+}

--- a/src/ViewModels/ExtensionViewModel.cs
+++ b/src/ViewModels/ExtensionViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
@@ -13,14 +13,24 @@ namespace GeneralUpdate.Tools.ViewModels;
 public partial class ExtensionViewModel : ViewModelBase
 {
     private readonly PackageService _pkg = new();
+    private readonly LocalizationService _loc = LocalizationService.Instance;
+
     public ExtensionConfigModel Config { get; } = new();
     [ObservableProperty] private bool _isBuilding;
-    [ObservableProperty] private string _status = "就绪";
+    [ObservableProperty] private string _status;
     [ObservableProperty] private string _newPropKey = "";
     [ObservableProperty] private string _newPropValue = "";
     public ObservableCollection<CustomPropModel> CustomProps { get; } = new();
 
-    async Task<string?> Pick() { var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow); if (tl == null) return null; var r = await tl.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions { Title = "选择目录", AllowMultiple = false }); return r.Count > 0 ? r[0].Path.LocalPath : null; }
+    public ExtensionViewModel() { _status = _loc["Patch.Ready"]; }
+
+    async Task<string?> Pick()
+    {
+        var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow);
+        if (tl == null) return null;
+        var r = await tl.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions { Title = _loc["Patch.Select"], AllowMultiple = false });
+        return r.Count > 0 ? r[0].Path.LocalPath : null;
+    }
 
     [RelayCommand] async Task SelectExt() { var p = await Pick(); if (p != null) Config.ExtensionDirectory = p; }
     [RelayCommand] async Task SelectExport() { var p = await Pick(); if (p != null) Config.ExportPath = p; }
@@ -29,9 +39,9 @@ public partial class ExtensionViewModel : ViewModelBase
 
     [RelayCommand] async Task Generate()
     {
-        if (string.IsNullOrWhiteSpace(Config.Name) || string.IsNullOrWhiteSpace(Config.Version)) { Status = "请填写扩展名称和版本"; return; }
-        if (string.IsNullOrWhiteSpace(Config.ExtensionDirectory) || !Directory.Exists(Config.ExtensionDirectory)) { Status = "请选择有效的扩展目录"; return; }
-        IsBuilding = true; Status = "正在生成扩展包...";
+        if (string.IsNullOrWhiteSpace(Config.Name) || string.IsNullOrWhiteSpace(Config.Version)) { Status = _loc["Ext.ValidateNameVer"]; return; }
+        if (string.IsNullOrWhiteSpace(Config.ExtensionDirectory) || !Directory.Exists(Config.ExtensionDirectory)) { Status = _loc["Ext.ValidateDir"]; return; }
+        IsBuilding = true; Status = _loc["Ext.Building"];
         try
         {
             var dir = string.IsNullOrWhiteSpace(Config.ExportPath) ? Environment.GetFolderPath(Environment.SpecialFolder.Desktop) : Config.ExportPath;
@@ -45,9 +55,9 @@ public partial class ExtensionViewModel : ViewModelBase
                 customProperties = CustomProps.ToDictionary(p => p.Key, p => p.Value)
             });
             Config.OutputPath = zip;
-            Status = $"成功: {Path.GetFileName(zip)}";
+            Status = _loc.T("Ext.Success", Path.GetFileName(zip));
         }
-        catch (Exception ex) { Status = $"失败: {ex.Message}"; }
+        catch (Exception ex) { Status = _loc.T("Ext.Failed", ex.Message); }
         finally { IsBuilding = false; }
     }
     static string Sanitize(string n) => string.Join("_", n.Split(Path.GetInvalidFileNameChars()));

--- a/src/ViewModels/ExtensionViewModel.cs
+++ b/src/ViewModels/ExtensionViewModel.cs
@@ -24,11 +24,20 @@ public partial class ExtensionViewModel : ViewModelBase
 
     public ExtensionViewModel() { _status = _loc["Patch.Ready"]; }
 
+    string GetFolderPickerTitle()
+    {
+        var title = _loc["Ext.SelectDirectoryTitle"];
+        if (!string.IsNullOrWhiteSpace(title) && title != "Ext.SelectDirectoryTitle") return title;
+        return string.Equals(System.Globalization.CultureInfo.CurrentUICulture.TwoLetterISOLanguageName, "zh", StringComparison.OrdinalIgnoreCase)
+            ? "选择目录"
+            : "Select folder";
+    }
+
     async Task<string?> Pick()
     {
         var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow);
         if (tl == null) return null;
-        var r = await tl.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions { Title = _loc["Patch.Select"], AllowMultiple = false });
+        var r = await tl.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions { Title = GetFolderPickerTitle(), AllowMultiple = false });
         return r.Count > 0 ? r[0].Path.LocalPath : null;
     }
 

--- a/src/ViewModels/MainWindowViewModel.cs
+++ b/src/ViewModels/MainWindowViewModel.cs
@@ -1,24 +1,65 @@
-﻿using System.Collections.ObjectModel;
-using System.Linq;
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using GeneralUpdate.Tools.Models;
+using GeneralUpdate.Tools.Services;
 
 namespace GeneralUpdate.Tools.ViewModels;
 
 public partial class MainWindowViewModel : ViewModelBase
 {
+    private readonly LocalizationService _loc = LocalizationService.Instance;
+
     [ObservableProperty] private ViewModelBase _currentPage = new PatchViewModel();
+    [ObservableProperty] private bool _isDarkTheme;
+    [ObservableProperty] private string _themeButtonText = "🌙";
+    [ObservableProperty] private string _localeText = "EN";
+
     public ObservableCollection<NavItem> NavItems { get; } = new();
 
     public MainWindowViewModel()
     {
-        NavItems.Add(new("Patch", "补丁包", typeof(PatchViewModel), true));
-        NavItems.Add(new("Extension", "扩展包", typeof(ExtensionViewModel), false));
-        NavItems.Add(new("OSS", "OSS配置", typeof(OSSViewModel), false));
+        SyncNavItems();
+        _loc.PropertyChanged += (_, _) => { SyncNavItems(); LocaleText = _loc.Locale == "zh-CN" ? "EN" : "中"; };
     }
 
-    [RelayCommand] private void Navigate(NavItem item) { foreach (var n in NavItems) n.IsSelected = false; item.IsSelected = true; CurrentPage = item.Key switch { "Patch" => new PatchViewModel(), "Extension" => new ExtensionViewModel(), _ => new OSSViewModel() }; }
+    private void SyncNavItems()
+    {
+        NavItems.Clear();
+        NavItems.Add(new("Patch", _loc["Nav.Patch"], typeof(PatchViewModel), true));
+        NavItems.Add(new("Extension", _loc["Nav.Extension"], typeof(ExtensionViewModel), false));
+        NavItems.Add(new("OSS", _loc["Nav.OSS"], typeof(OSSViewModel), false));
+    }
+
+    [RelayCommand] private void Navigate(NavItem item)
+    {
+        foreach (var n in NavItems) n.IsSelected = false;
+        item.IsSelected = true;
+        CurrentPage = item.Key switch
+        {
+            "Patch" => new PatchViewModel(),
+            "Extension" => new ExtensionViewModel(),
+            _ => new OSSViewModel()
+        };
+    }
+
+    [RelayCommand]
+    private void ToggleTheme()
+    {
+        IsDarkTheme = !IsDarkTheme;
+        ThemeButtonText = IsDarkTheme ? "☀️" : "🌙";
+        var app = Avalonia.Application.Current;
+        if (app != null)
+            app.RequestedThemeVariant = IsDarkTheme
+                ? Avalonia.Styling.ThemeVariant.Dark
+                : Avalonia.Styling.ThemeVariant.Light;
+    }
+
+    [RelayCommand]
+    private void ToggleLocale()
+    {
+        _loc.Locale = _loc.Locale == "zh-CN" ? "en-US" : "zh-CN";
+    }
 }
 
 public partial class NavItem : ObservableObject

--- a/src/ViewModels/MainWindowViewModel.cs
+++ b/src/ViewModels/MainWindowViewModel.cs
@@ -20,7 +20,14 @@ public partial class MainWindowViewModel : ViewModelBase
     public MainWindowViewModel()
     {
         SyncNavItems();
-        _loc.PropertyChanged += (_, _) => { SyncNavItems(); LocaleText = _loc.Locale == "zh-CN" ? "EN" : "中"; };
+        _loc.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName != nameof(LocalizationService.Locale))
+                return;
+
+            SyncNavItems();
+            LocaleText = _loc.Locale == "zh-CN" ? "EN" : "中";
+        };
     }
 
     private void SyncNavItems()

--- a/src/ViewModels/OSSViewModel.cs
+++ b/src/ViewModels/OSSViewModel.cs
@@ -21,11 +21,22 @@ public partial class OSSViewModel : ViewModelBase
 
     public OSSViewModel() { _status = _loc["Patch.Ready"]; }
 
+    private string GetOpenFilePickerTitle()
+    {
+        var title = _loc["Patch.SelectFile"];
+        if (string.IsNullOrWhiteSpace(title) || title == "Patch.SelectFile" || title == _loc["Patch.Select"])
+        {
+            return "选择文件";
+        }
+
+        return title;
+    }
+
     [RelayCommand] async Task ComputeHash()
     {
         var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow);
         if (tl == null) return;
-        var files = await tl.StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions { Title = _loc["Patch.Select"], AllowMultiple = false });
+        var files = await tl.StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions { Title = GetOpenFilePickerTitle(), AllowMultiple = false });
         if (files.Count > 0) { Current.Hash = await _hash.ComputeHashAsync(files[0].Path.LocalPath); Status = _loc.T("OSS.HashResult", Current.Hash); }
     }
     [RelayCommand] void Append() { Configs.Add(new() { PacketName = Current.PacketName, Hash = Current.Hash, Version = Current.Version, Url = Current.Url, ReleaseDate = Current.ReleaseDate }); Status = _loc["OSS.Added"]; }

--- a/src/ViewModels/OSSViewModel.cs
+++ b/src/ViewModels/OSSViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading.Tasks;
@@ -13,13 +13,29 @@ namespace GeneralUpdate.Tools.ViewModels;
 public partial class OSSViewModel : ViewModelBase
 {
     private readonly HashService _hash = new();
+    private readonly LocalizationService _loc = LocalizationService.Instance;
+
     public ObservableCollection<OSSConfigModel> Configs { get; } = new();
     [ObservableProperty] private OSSConfigModel _current = new();
-    [ObservableProperty] private string _status = "就绪";
+    [ObservableProperty] private string _status;
 
-    [RelayCommand] async Task ComputeHash() { var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow); if (tl == null) return; var files = await tl.StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions { Title = "选择文件", AllowMultiple = false }); if (files.Count > 0) { Current.Hash = await _hash.ComputeHashAsync(files[0].Path.LocalPath); Status = $"SHA256: {Current.Hash}"; } }
-    [RelayCommand] void Append() { Configs.Add(new() { PacketName = Current.PacketName, Hash = Current.Hash, Version = Current.Version, Url = Current.Url, ReleaseDate = Current.ReleaseDate }); Status = "已添加"; }
+    public OSSViewModel() { _status = _loc["Patch.Ready"]; }
+
+    [RelayCommand] async Task ComputeHash()
+    {
+        var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow);
+        if (tl == null) return;
+        var files = await tl.StorageProvider.OpenFilePickerAsync(new Avalonia.Platform.Storage.FilePickerOpenOptions { Title = _loc["Patch.Select"], AllowMultiple = false });
+        if (files.Count > 0) { Current.Hash = await _hash.ComputeHashAsync(files[0].Path.LocalPath); Status = _loc.T("OSS.HashResult", Current.Hash); }
+    }
+    [RelayCommand] void Append() { Configs.Add(new() { PacketName = Current.PacketName, Hash = Current.Hash, Version = Current.Version, Url = Current.Url, ReleaseDate = Current.ReleaseDate }); Status = _loc["OSS.Added"]; }
     [RelayCommand] void Remove(OSSConfigModel? item) { if (item != null) Configs.Remove(item); }
-    [RelayCommand] void Clear() { Configs.Clear(); Status = "已清空"; }
-    [RelayCommand] async Task Export() { var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow); if (tl == null) return; var file = await tl.StorageProvider.SaveFilePickerAsync(new Avalonia.Platform.Storage.FilePickerSaveOptions { Title = "导出JSON", DefaultExtension = ".json", SuggestedFileName = "oss_config.json" }); if (file != null) { await File.WriteAllTextAsync(file.Path.LocalPath, JsonConvert.SerializeObject(Configs, Formatting.Indented), System.Text.Encoding.UTF8); Status = $"导出: {Configs.Count} 条"; } }
+    [RelayCommand] void Clear() { Configs.Clear(); Status = _loc["OSS.Cleared"]; }
+    [RelayCommand] async Task Export()
+    {
+        var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow);
+        if (tl == null) return;
+        var file = await tl.StorageProvider.SaveFilePickerAsync(new Avalonia.Platform.Storage.FilePickerSaveOptions { Title = _loc["OSS.Export"], DefaultExtension = ".json", SuggestedFileName = "oss_config.json" });
+        if (file != null) { await File.WriteAllTextAsync(file.Path.LocalPath, JsonConvert.SerializeObject(Configs, Formatting.Indented), System.Text.Encoding.UTF8); Status = _loc.T("OSS.Exported", Configs.Count); }
+    }
 }

--- a/src/ViewModels/PatchViewModel.cs
+++ b/src/ViewModels/PatchViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Threading.Tasks;
@@ -13,40 +13,53 @@ public partial class PatchViewModel : ViewModelBase
 {
     private readonly DiffService _diff = new();
     private readonly PackageService _pkg = new();
+    private readonly LocalizationService _loc = LocalizationService.Instance;
+
     public PatchConfigModel Config { get; } = new();
     [ObservableProperty] private bool _isBuilding;
     [ObservableProperty] private double _progress;
-    [ObservableProperty] private string _status = "就绪";
+    [ObservableProperty] private string _status;
     [ObservableProperty] private ObservableCollection<string> _log = new();
 
-    async Task<string?> Pick() { var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow); if (tl == null) return null; var r = await tl.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions { Title = "选择目录", AllowMultiple = false }); return r.Count > 0 ? r[0].Path.LocalPath : null; }
+    public PatchViewModel()
+    {
+        _status = _loc["Patch.Ready"];
+    }
 
-    [RelayCommand] async Task SelectOld() { var p = await Pick(); if (p != null) { Config.OldDirectory = p; L($"旧版本: {p}"); } }
-    [RelayCommand] async Task SelectNew() { var p = await Pick(); if (p != null) { Config.NewDirectory = p; L($"新版本: {p}"); } }
+    async Task<string?> Pick()
+    {
+        var tl = Avalonia.Controls.TopLevel.GetTopLevel((Avalonia.Application.Current?.ApplicationLifetime as Avalonia.Controls.ApplicationLifetimes.IClassicDesktopStyleApplicationLifetime)?.MainWindow);
+        if (tl == null) return null;
+        var r = await tl.StorageProvider.OpenFolderPickerAsync(new Avalonia.Platform.Storage.FolderPickerOpenOptions { Title = _loc["Patch.Select"], AllowMultiple = false });
+        return r.Count > 0 ? r[0].Path.LocalPath : null;
+    }
+
+    [RelayCommand] async Task SelectOld() { var p = await Pick(); if (p != null) { Config.OldDirectory = p; L(_loc.T("Patch.OldSelected", p)); } }
+    [RelayCommand] async Task SelectNew() { var p = await Pick(); if (p != null) { Config.NewDirectory = p; L(_loc.T("Patch.NewSelected", p)); } }
     [RelayCommand] async Task SelectOut() { var p = await Pick(); if (p != null) Config.OutputPath = p; }
 
     [RelayCommand] async Task Build()
     {
-        if (string.IsNullOrWhiteSpace(Config.OldDirectory) || string.IsNullOrWhiteSpace(Config.NewDirectory)) { Status = "请选择新旧版本目录"; return; }
-        IsBuilding = true; Log.Clear(); Progress = 0; Status = "正在生成差分补丁...";
+        if (string.IsNullOrWhiteSpace(Config.OldDirectory) || string.IsNullOrWhiteSpace(Config.NewDirectory)) { Status = _loc["Patch.ValidateDirs"]; return; }
+        IsBuilding = true; Log.Clear(); Progress = 0; Status = _loc["Patch.Building"];
         try
         {
             var tmp = Path.Combine(Path.GetTempPath(), $"gupatch_{DateTime.Now:yyyyMMddHHmmss}"); Directory.CreateDirectory(tmp);
-            L($"临时目录: {tmp}"); Progress = 20;
-            L("对比目录差异 + 生成 BSDiff40 补丁...");
+            L(_loc.T("Patch.TempDir", tmp)); Progress = 20;
+            L(_loc["Patch.Comparing"]);
             await _diff.GeneratePatchAsync(Config.OldDirectory, Config.NewDirectory, tmp);
-            Progress = 70; L("补丁生成完成");
+            Progress = 70; L(_loc["Patch.PatchDone"]);
             var outDir = string.IsNullOrWhiteSpace(Config.OutputPath) ? Environment.GetFolderPath(Environment.SpecialFolder.Desktop) : Config.OutputPath;
             var name = string.IsNullOrWhiteSpace(Config.PackageName) ? $"patch_{DateTime.Now:yyyyMMddHHmmss}" : Config.PackageName;
             var zip = Path.Combine(outDir, $"{name}.zip");
-            L($"打包: {Path.GetFileName(zip)}");
+            L(_loc.T("Patch.Packing", Path.GetFileName(zip)));
             await _pkg.CompressDirectoryAsync(tmp, zip);
             Directory.Delete(tmp, true);
             Progress = 100; Config.OutputPath = zip;
-            Status = $"成功: {Path.GetFileName(zip)} ({new FileInfo(zip).Length/1024.0:F1} KB)";
+            Status = _loc.T("Patch.Success", Path.GetFileName(zip), new FileInfo(zip).Length / 1024.0);
             L(Status);
         }
-        catch (Exception ex) { Status = $"失败: {ex.Message}"; L($"错误: {ex}"); }
+        catch (Exception ex) { Status = _loc.T("Patch.Failed", ex.Message); L(_loc.T("Patch.Error", ex)); }
         finally { IsBuilding = false; }
     }
     void L(string m) => Log.Add($"[{DateTime.Now:HH:mm:ss}] {m}");

--- a/src/Views/ExtensionView.axaml
+++ b/src/Views/ExtensionView.axaml
@@ -1,44 +1,60 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:GeneralUpdate.Tools.ViewModels"
-             x:Class="GeneralUpdate.Tools.Views.ExtensionView" x:Name="ExtRoot"
+             xmlns:svc="using:GeneralUpdate.Tools.Services"
+             x:Class="GeneralUpdate.Tools.Views.ExtensionView"
+             x:Name="ExtRoot"
              x:DataType="vm:ExtensionViewModel">
     <ScrollViewer>
         <StackPanel Margin="28,24" Spacing="14">
-            <TextBlock Text="扩展包生成" FontSize="20" FontWeight="Bold"/>
+            <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Title]}"
+                       FontSize="20" FontWeight="Bold"/>
+
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="基本信息" FontSize="14" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.BasicInfo]}" FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
-                        <TextBlock Grid.Column="0" Text="名称" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Name]}" VerticalAlignment="Center"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.Name}" PlaceholderText="MyExtension" Margin="8,0,16,0"/>
-                        <TextBlock Grid.Column="2" Text="版本" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Version]}" VerticalAlignment="Center"/>
                         <TextBox Grid.Column="3" Text="{Binding Config.Version}" PlaceholderText="1.0.0.0" Margin="8,0"/>
                     </Grid>
-                    <TextBlock Text="描述"/>
-                    <TextBox Text="{Binding Config.Description}" PlaceholderText="扩展功能描述..." Height="50" AcceptsReturn="True"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Description]}"/>
+                    <TextBox Text="{Binding Config.Description}" PlaceholderText="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.DescPlaceholder]}"
+                             Height="50" AcceptsReturn="True"/>
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
-                        <TextBlock Grid.Column="0" Text="发布者" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Publisher]}" VerticalAlignment="Center"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.Publisher}" Margin="8,0,16,0"/>
-                        <TextBlock Grid.Column="2" Text="许可证" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="3" Text="{Binding Config.License}" PlaceholderText="MIT" Margin="8,0"/>
+                        <TextBlock Grid.Column="2" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.License]}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="3" Text="{Binding Config.License}"
+                                 PlaceholderText="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.LicensePlaceholder]}" Margin="8,0"/>
                     </Grid>
                 </StackPanel>
             </Border>
+
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="路径" FontSize="14" FontWeight="SemiBold"/>
-                    <Grid ColumnDefinitions="Auto,*,Auto"><TextBlock Grid.Column="0" Text="扩展目录" VerticalAlignment="Center" Width="75"/><TextBox Grid.Column="1" Text="{Binding Config.ExtensionDirectory}" IsReadOnly="True" Margin="8,0"/><Button Grid.Column="2" Content="选择" Command="{Binding SelectExtCommand}" MinWidth="70"/></Grid>
-                    <Grid ColumnDefinitions="Auto,*,Auto"><TextBlock Grid.Column="0" Text="导出目录" VerticalAlignment="Center" Width="75"/><TextBox Grid.Column="1" Text="{Binding Config.ExportPath}" IsReadOnly="True" Margin="8,0"/><Button Grid.Column="2" Content="选择" Command="{Binding SelectExportCommand}" MinWidth="70"/></Grid>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Paths]}" FontSize="14" FontWeight="SemiBold"/>
+                    <Grid ColumnDefinitions="Auto,*,Auto">
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.ExtDir]}" VerticalAlignment="Center" Width="75"/>
+                        <TextBox Grid.Column="1" Text="{Binding Config.ExtensionDirectory}" IsReadOnly="True" Margin="8,0"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.Select]}" Command="{Binding SelectExtCommand}" MinWidth="70"/>
+                    </Grid>
+                    <Grid ColumnDefinitions="Auto,*,Auto">
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.ExportDir]}" VerticalAlignment="Center" Width="75"/>
+                        <TextBox Grid.Column="1" Text="{Binding Config.ExportPath}" IsReadOnly="True" Margin="8,0"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.Select]}" Command="{Binding SelectExportCommand}" MinWidth="70"/>
+                    </Grid>
                 </StackPanel>
             </Border>
+
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="自定义属性" FontSize="14" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.CustomProps]}" FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="*,*,Auto">
-                        <TextBox Grid.Column="0" Text="{Binding NewPropKey}" PlaceholderText="Key" Margin="0,0,8,0"/>
-                        <TextBox Grid.Column="1" Text="{Binding NewPropValue}" PlaceholderText="Value" Margin="0,0,8,0"/>
-                        <Button Grid.Column="2" Content="+ 添加" Command="{Binding AddPropCommand}" MinWidth="60"/>
+                        <TextBox Grid.Column="0" Text="{Binding NewPropKey}" PlaceholderText="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Key]}" Margin="0,0,8,0"/>
+                        <TextBox Grid.Column="1" Text="{Binding NewPropValue}" PlaceholderText="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Value]}" Margin="0,0,8,0"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.AddProp]}" Command="{Binding AddPropCommand}" MinWidth="60"/>
                     </Grid>
                     <ItemsControl ItemsSource="{Binding CustomProps}">
                         <ItemsControl.ItemTemplate>
@@ -46,14 +62,19 @@
                                 <Grid ColumnDefinitions="*,*,Auto">
                                     <TextBlock Grid.Column="0" Text="{Binding Key}"/>
                                     <TextBlock Grid.Column="1" Text="{Binding Value}"/>
-                                    <Button Grid.Column="2" Content="X" Command="{Binding ElementName=ExtRoot, Path=DataContext.RemovePropCommand}" CommandParameter="{Binding}"/>
+                                    <Button Grid.Column="2" Content="✕"
+                                            Command="{Binding ElementName=ExtRoot, Path=DataContext.RemovePropCommand}"
+                                            CommandParameter="{Binding}"/>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
             </Border>
-            <Button Content="生成扩展包" Command="{Binding GenerateCommand}" IsEnabled="{Binding !IsBuilding}" Height="40" FontSize="14" HorizontalAlignment="Stretch"/>
+
+            <Button Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Generate]}"
+                    Command="{Binding GenerateCommand}" IsEnabled="{Binding !IsBuilding}"
+                    Height="40" FontSize="14" HorizontalAlignment="Stretch"/>
             <TextBlock Text="{Binding Status}" FontSize="13"/>
         </StackPanel>
     </ScrollViewer>

--- a/src/Views/MainWindow.axaml
+++ b/src/Views/MainWindow.axaml
@@ -1,17 +1,24 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:GeneralUpdate.Tools.ViewModels"
+        xmlns:svc="using:GeneralUpdate.Tools.Services"
         x:Class="GeneralUpdate.Tools.Views.MainWindow"
         x:Name="MainWin"
         x:DataType="vm:MainWindowViewModel"
-        Title="GeneralUpdate Tools" Width="960" Height="640" MinWidth="780" MinHeight="540"
+        Title="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[App.Title]}"
+        Width="960" Height="640" MinWidth="780" MinHeight="540"
         WindowStartupLocation="CenterScreen">
     <DockPanel>
+        <!-- Left Sidebar -->
         <Border DockPanel.Dock="Left" Width="200" Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
-            <Grid RowDefinitions="Auto,*">
+            <Grid RowDefinitions="Auto,*,Auto">
+                <!-- Title -->
                 <Border Grid.Row="0" Padding="18,20,18,12">
-                    <TextBlock Text="GeneralUpdate Tools" FontSize="16" FontWeight="Bold"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[App.Title]}"
+                               FontSize="16" FontWeight="Bold"/>
                 </Border>
+
+                <!-- Nav Items -->
                 <ItemsControl Grid.Row="1" ItemsSource="{Binding NavItems}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate x:DataType="vm:NavItem">
@@ -28,8 +35,24 @@
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
+
+                <!-- Bottom controls: theme + locale -->
+                <StackPanel Grid.Row="2" Orientation="Horizontal"
+                            HorizontalAlignment="Center" Spacing="4" Margin="8,12">
+                    <Button Content="{Binding ThemeButtonText}"
+                            Command="{Binding ToggleThemeCommand}"
+                            Background="Transparent" BorderThickness="0"
+                            FontSize="16" Width="40" Height="36"
+                            ToolTip.Tip="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Theme.Toggle]}"/>
+                    <Button Content="{Binding LocaleText}"
+                            Command="{Binding ToggleLocaleCommand}"
+                            Background="Transparent" BorderThickness="0"
+                            FontSize="14" Width="40" Height="36"/>
+                </StackPanel>
             </Grid>
         </Border>
+
+        <!-- Content Area -->
         <ContentControl Content="{Binding CurrentPage}"/>
     </DockPanel>
 </Window>

--- a/src/Views/OSSView.axaml
+++ b/src/Views/OSSView.axaml
@@ -1,39 +1,68 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:GeneralUpdate.Tools.ViewModels"
              xmlns:m="using:GeneralUpdate.Tools.Models"
-             x:Class="GeneralUpdate.Tools.Views.OSSView" x:Name="OssRoot"
+             xmlns:svc="using:GeneralUpdate.Tools.Services"
+             x:Class="GeneralUpdate.Tools.Views.OSSView"
+             x:Name="OssRoot"
              x:DataType="vm:OSSViewModel">
     <ScrollViewer>
         <StackPanel Margin="28,24" Spacing="14">
-            <TextBlock Text="OSS 配置生成" FontSize="20" FontWeight="Bold"/>
+            <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.Title]}"
+                       FontSize="20" FontWeight="Bold"/>
+
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="新建条目" FontSize="14" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.NewEntry]}" FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
-                        <TextBlock Grid.Column="0" Text="包名" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.PacketName]}" VerticalAlignment="Center"/>
                         <TextBox Grid.Column="1" Text="{Binding Current.PacketName}" Margin="8,0,16,0"/>
-                        <TextBlock Grid.Column="2" Text="版本" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.Version]}" VerticalAlignment="Center"/>
                         <TextBox Grid.Column="3" Text="{Binding Current.Version}" Margin="8,0"/>
                     </Grid>
-                    <Grid ColumnDefinitions="Auto,*"><TextBlock Grid.Column="0" Text="URL" VerticalAlignment="Center"/><TextBox Grid.Column="1" Text="{Binding Current.Url}" Margin="8,0"/></Grid>
-                    <Grid ColumnDefinitions="Auto,*,Auto"><TextBlock Grid.Column="0" Text="SHA256" Width="55" VerticalAlignment="Center"/><TextBox Grid.Column="1" Text="{Binding Current.Hash}" IsReadOnly="True" Margin="8,0"/><Button Grid.Column="2" Content="计算" Command="{Binding ComputeHashCommand}" MinWidth="60"/></Grid>
-                    <Button Content="添加到列表" Command="{Binding AppendCommand}" Height="34" HorizontalAlignment="Stretch"/>
+                    <Grid ColumnDefinitions="Auto,*">
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.Url]}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="1" Text="{Binding Current.Url}" Margin="8,0"/>
+                    </Grid>
+                    <Grid ColumnDefinitions="Auto,*,Auto">
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.SHA256]}" Width="55" VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="1" Text="{Binding Current.Hash}" IsReadOnly="True" Margin="8,0"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.ComputeHash]}" Command="{Binding ComputeHashCommand}" MinWidth="60"/>
+                    </Grid>
+                    <Button Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.AddToList]}"
+                            Command="{Binding AppendCommand}" Height="34" HorizontalAlignment="Stretch"/>
                 </StackPanel>
             </Border>
+
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <Grid ColumnDefinitions="*,Auto"><TextBlock Text="配置列表" FontSize="14" FontWeight="SemiBold"/><Button Grid.Column="1" Content="清空" Command="{Binding ClearCommand}"/></Grid>
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.ConfigList]}" FontSize="14" FontWeight="SemiBold"/>
+                        <Button Grid.Column="1" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.Clear]}" Command="{Binding ClearCommand}"/>
+                    </Grid>
                     <ItemsControl ItemsSource="{Binding Configs}" MaxHeight="260">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="m:OSSConfigModel">
-                                <Border Padding="8" Margin="0,2"><Grid ColumnDefinitions="*,Auto"><StackPanel Grid.Column="0" Spacing="2"><TextBlock FontWeight="SemiBold" Text="{Binding PacketName}"/><TextBlock FontSize="10" Foreground="Gray" Text="{Binding Hash}"/><TextBlock FontSize="11" Text="{Binding Version}"/></StackPanel><Button Grid.Column="1" Content="X" VerticalAlignment="Center" Command="{Binding ElementName=OssRoot, Path=DataContext.RemoveCommand}" CommandParameter="{Binding}"/></Grid></Border>
+                                <Border Padding="8" Margin="0,2">
+                                    <Grid ColumnDefinitions="*,Auto">
+                                        <StackPanel Grid.Column="0" Spacing="2">
+                                            <TextBlock FontWeight="SemiBold" Text="{Binding PacketName}"/>
+                                            <TextBlock FontSize="10" Foreground="Gray" Text="{Binding Hash}"/>
+                                            <TextBlock FontSize="11" Text="{Binding Version}"/>
+                                        </StackPanel>
+                                        <Button Grid.Column="1" Content="✕" VerticalAlignment="Center"
+                                                Command="{Binding ElementName=OssRoot, Path=DataContext.RemoveCommand}"
+                                                CommandParameter="{Binding}"/>
+                                    </Grid>
+                                </Border>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                 </StackPanel>
             </Border>
-            <Button Content="导出 JSON" Command="{Binding ExportCommand}" Height="40" FontSize="14" HorizontalAlignment="Stretch"/>
+
+            <Button Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[OSS.Export]}"
+                    Command="{Binding ExportCommand}" Height="40" FontSize="14" HorizontalAlignment="Stretch"/>
             <TextBlock Text="{Binding Status}" FontSize="13"/>
         </StackPanel>
     </ScrollViewer>

--- a/src/Views/PatchView.axaml
+++ b/src/Views/PatchView.axaml
@@ -1,47 +1,65 @@
-﻿<UserControl xmlns="https://github.com/avaloniaui"
+<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:GeneralUpdate.Tools.ViewModels"
+             xmlns:svc="using:GeneralUpdate.Tools.Services"
              x:Class="GeneralUpdate.Tools.Views.PatchView"
              x:DataType="vm:PatchViewModel">
     <ScrollViewer>
         <StackPanel Margin="28,24" Spacing="14">
-            <TextBlock Text="补丁包生成" FontSize="20" FontWeight="Bold"/>
+            <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.Title]}"
+                       FontSize="20" FontWeight="Bold"/>
+
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="核心路径" FontSize="14" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.CorePaths]}"
+                               FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <TextBlock Grid.Column="0" Text="旧版本目录" VerticalAlignment="Center" Width="85"/>
-                        <TextBox Grid.Column="1" Text="{Binding Config.OldDirectory}" PlaceholderText="选择旧版本应用目录..." IsReadOnly="True" Margin="8,0"/>
-                        <Button Grid.Column="2" Content="选择" Command="{Binding SelectOldCommand}" MinWidth="70"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.OldDir]}"
+                                   VerticalAlignment="Center" Width="85"/>
+                        <TextBox Grid.Column="1" Text="{Binding Config.OldDirectory}"
+                                 PlaceholderText="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.OldPlaceholder]}"
+                                 IsReadOnly="True" Margin="8,0"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.Select]}"
+                                Command="{Binding SelectOldCommand}" MinWidth="70"/>
                     </Grid>
                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <TextBlock Grid.Column="0" Text="新版本目录" VerticalAlignment="Center" Width="85"/>
-                        <TextBox Grid.Column="1" Text="{Binding Config.NewDirectory}" PlaceholderText="选择新版本发布目录..." IsReadOnly="True" Margin="8,0"/>
-                        <Button Grid.Column="2" Content="选择" Command="{Binding SelectNewCommand}" MinWidth="70"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.NewDir]}"
+                                   VerticalAlignment="Center" Width="85"/>
+                        <TextBox Grid.Column="1" Text="{Binding Config.NewDirectory}"
+                                 PlaceholderText="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.NewPlaceholder]}"
+                                 IsReadOnly="True" Margin="8,0"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.Select]}"
+                                Command="{Binding SelectNewCommand}" MinWidth="70"/>
                     </Grid>
                 </StackPanel>
             </Border>
+
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="包信息" FontSize="14" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.PackageInfo]}"
+                               FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
-                        <TextBlock Grid.Column="0" Text="包名" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1" Text="{Binding Config.PackageName}" PlaceholderText="例如: patch_v1.0_to_v1.1" Margin="8,0,16,0"/>
-                        <TextBlock Grid.Column="2" Text="版本" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.PackageName]}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="1" Text="{Binding Config.PackageName}" PlaceholderText="patch_v1.0_to_v1.1" Margin="8,0,16,0"/>
+                        <TextBlock Grid.Column="2" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.Version]}" VerticalAlignment="Center"/>
                         <TextBox Grid.Column="3" Text="{Binding Config.Version}" PlaceholderText="1.0.0.0" Margin="8,0"/>
                     </Grid>
                     <Grid ColumnDefinitions="Auto,*,Auto,Auto">
-                        <TextBlock Grid.Column="0" Text="输出目录" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1" Text="{Binding Config.OutputPath}" PlaceholderText="桌面 (默认)" IsReadOnly="True" Margin="8,0,16,0"/>
-                        <Button Grid.Column="2" Content="选择" Command="{Binding SelectOutCommand}" MinWidth="70"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.OutputDir]}" VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="1" Text="{Binding Config.OutputPath}"
+                                 PlaceholderText="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.OutputPlaceholder]}"
+                                 IsReadOnly="True" Margin="8,0,16,0"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.Select]}"
+                                Command="{Binding SelectOutCommand}" MinWidth="70"/>
                     </Grid>
                 </StackPanel>
             </Border>
-            <Button Content="开始构建" Command="{Binding BuildCommand}" IsEnabled="{Binding !IsBuilding}" Height="40" FontSize="14" HorizontalAlignment="Stretch"/>
+
+            <Button Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.Build]}"
+                    Command="{Binding BuildCommand}" IsEnabled="{Binding !IsBuilding}"
+                    Height="40" FontSize="14" HorizontalAlignment="Stretch"/>
             <ProgressBar IsVisible="{Binding IsBuilding}" Value="{Binding Progress}" Height="6"/>
-            <Border Padding="10" CornerRadius="6" Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}">
-                <TextBlock Text="{Binding Status}" FontSize="13"/>
-            </Border>
+            <TextBlock Text="{Binding Status}" FontSize="13"/>
             <Border Padding="10" CornerRadius="6" Background="{DynamicResource SystemControlBackgroundChromeMediumLowBrush}" MaxHeight="180">
                 <ListBox ItemsSource="{Binding Log}" Background="Transparent" BorderThickness="0">
                     <ListBox.ItemTemplate>


### PR DESCRIPTION
﻿## Summary
Add multi-language support (zh-CN / en-US) and dark/light theme toggle.

### Changes
- **LocalizationService**: dictionary-based i18n, 70+ strings covering all UI labels
- **Theme toggle**: 🌙/☀️ button in sidebar bottom, switches between Light/Dark
- **Locale toggle**: EN/中 button in sidebar bottom, switches between English/Chinese
- All ViewModels use LocalizationService.Instance["key"] for status/error messages
- All XAML labels use {x:Static svc:LocalizationService.Instance} bindings
- Navigation items re-sync when locale changes

### How it works
- LocalizationService.Instance.Locale = "zh-CN" | "en-US"
- Toggle button switches locale, all bound labels update automatically
- Theme applies via Application.Current.RequestedThemeVariant
- Semi theme respects the variant for proper Dark/Light styling

### Files
- New: Services/LocalizationService.cs
- Modified: 4 ViewModels, 4 Views

Build: 0 warnings / 0 errors
