### PR TITLE
fix: Simulate Platform/AppType ComboBox InvalidCastException and layout

### DIFF
--- a/src/Models/SimulateConfigModel.cs
+++ b/src/Models/SimulateConfigModel.cs
@@ -2,6 +2,9 @@ using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace GeneralUpdate.Tools.Models;
 
+public record PlatformItem(int Value, string DisplayName) { public override string ToString() => DisplayName; }
+public record AppTypeItem(int Value, string DisplayName) { public override string ToString() => DisplayName; }
+
 /// <summary>
 /// Configuration for the simulate-update module.
 /// </summary>
@@ -19,11 +22,11 @@ public partial class SimulateConfigModel : ObservableObject
     /// <summary>The target version the patch upgrades to.</summary>
     [ObservableProperty] private string _targetVersion = "2.0.0.0";
 
-    /// <summary>Platform selector (1=Windows, 2=Linux).</summary>
-    [ObservableProperty] private int _platform = 1;
+    /// <summary>Platform selector.</summary>
+    [ObservableProperty] private PlatformItem _platform = new(1, "Windows");
 
-    /// <summary>AppType sent to the server (1=ClientApp, 2=UpgradeApp).</summary>
-    [ObservableProperty] private int _appType = 1;
+    /// <summary>AppType selector.</summary>
+    [ObservableProperty] private AppTypeItem _appType = new(1, "ClientApp");
 
     /// <summary>Application secret key for the update API.</summary>
     [ObservableProperty] private string _appSecretKey = "dfeb5833-975e-4afb-88f1-6278ee9aeff6";

--- a/src/Services/ReportGeneratorService.cs
+++ b/src/Services/ReportGeneratorService.cs
@@ -26,8 +26,8 @@ public class ReportGeneratorService
         sb.AppendLine("|-------|-------|");
         sb.AppendLine($"| Patch | {EscapeMd(config.PatchFilePath)} |");
         sb.AppendLine($"| App Directory | {EscapeMd(config.AppDirectory)} |");
-        sb.AppendLine($"| Platform | {config.Platform} |");
-        sb.AppendLine($"| AppType | {config.AppType} |");
+        sb.AppendLine($"| Platform | {config.Platform.DisplayName} |");
+        sb.AppendLine($"| AppType | {config.AppType.DisplayName} |");
         sb.AppendLine($"| Version | {config.CurrentVersion} → {config.TargetVersion} |");
         sb.AppendLine($"| Server Port | {config.ServerPort} |");
         sb.AppendLine($"| Simulation Time | {DateTime.Now:yyyy-MM-dd HH:mm:ss} |");

--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -50,7 +50,7 @@ public class SimulationService
 
             var hash = ComputeQuickHash(patchDest);
             LocalUpdateServerFiles.Register(patchName, patchDest);
-            _server.Updates.Add((config.CurrentVersion, config.TargetVersion, hash, patchDest, config.AppType));
+            _server.Updates.Add((config.CurrentVersion, config.TargetVersion, hash, patchDest, config.AppType.Value));
 
             await _server.StartAsync(config.ServerPort);
             Log($"  Server running on {_server.BaseUrl}", progress);

--- a/src/ViewModels/SimulateViewModel.cs
+++ b/src/ViewModels/SimulateViewModel.cs
@@ -107,6 +107,3 @@ public partial class SimulateViewModel : ViewModelBase
 
     void L(string msg) => Log.Add($"[{DateTime.Now:HH:mm:ss}] {msg}");
 }
-
-public record PlatformItem(int Value, string DisplayName) { public override string ToString() => DisplayName; }
-public record AppTypeItem(int Value, string DisplayName) { public override string ToString() => DisplayName; }

--- a/src/Views/SimulateView.axaml
+++ b/src/Views/SimulateView.axaml
@@ -13,12 +13,12 @@
                 <StackPanel Spacing="10">
                     <TextBlock Text="Test Target" FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <TextBlock Grid.Column="0" Text="Old App Dir" VerticalAlignment="Center" Width="100"/>
+                        <TextBlock Grid.Column="0" Text="Old App Dir" VerticalAlignment="Center" Width="110"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.AppDirectory}" IsReadOnly="True" Margin="8,0"/>
                         <Button Grid.Column="2" Content="📁 Select" Command="{Binding SelectAppDirCommand}" MinWidth="80"/>
                     </Grid>
                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <TextBlock Grid.Column="0" Text="Patch Package" VerticalAlignment="Center" Width="100"/>
+                        <TextBlock Grid.Column="0" Text="Patch Package" VerticalAlignment="Center" Width="110"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.PatchFilePath}" IsReadOnly="True" Margin="8,0"/>
                         <Button Grid.Column="2" Content="📁 Select" Command="{Binding SelectPatchCommand}" MinWidth="80"/>
                     </Grid>
@@ -38,18 +38,18 @@
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
                         <TextBlock Grid.Column="0" Text="Platform" VerticalAlignment="Center"/>
                         <ComboBox Grid.Column="1" ItemsSource="{Binding Platforms}"
-                                  SelectedItem="{Binding Config.Platform}" Margin="8,0,16,0"/>
+                                  SelectedItem="{Binding Config.Platform}" Margin="8,0,16,0"
+                                  SelectedIndex="0"/>
                         <TextBlock Grid.Column="2" Text="AppType" VerticalAlignment="Center"/>
                         <ComboBox Grid.Column="3" ItemsSource="{Binding AppTypes}"
-                                  SelectedItem="{Binding Config.AppType}" Margin="8,0"/>
+                                  SelectedItem="{Binding Config.AppType}" Margin="8,0"
+                                  SelectedIndex="0"/>
                     </Grid>
-                    <Grid ColumnDefinitions="Auto,*">
+                    <Grid ColumnDefinitions="Auto,*,Auto,*">
                         <TextBlock Grid.Column="0" Text="AppSecret" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1" Text="{Binding Config.AppSecretKey}" Margin="8,0"/>
-                    </Grid>
-                    <Grid ColumnDefinitions="Auto,*">
-                        <TextBlock Grid.Column="0" Text="Product ID" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="1" Text="{Binding Config.ProductId}" Margin="8,0"/>
+                        <TextBox Grid.Column="1" Text="{Binding Config.AppSecretKey}" Margin="8,0,16,0"/>
+                        <TextBlock Grid.Column="2" Text="Product ID" VerticalAlignment="Center"/>
+                        <TextBox Grid.Column="3" Text="{Binding Config.ProductId}" Margin="8,0"/>
                     </Grid>
                 </StackPanel>
             </Border>
@@ -59,7 +59,7 @@
                 <StackPanel Spacing="10">
                     <TextBlock Text="Output" FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <TextBlock Grid.Column="0" Text="Simulate Dir" VerticalAlignment="Center" Width="100"/>
+                        <TextBlock Grid.Column="0" Text="Simulate Dir" VerticalAlignment="Center" Width="110"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.OutputDirectory}" IsReadOnly="True" Margin="8,0"/>
                         <Button Grid.Column="2" Content="📁 Select" Command="{Binding SelectOutputDirCommand}" MinWidth="80"/>
                     </Grid>


### PR DESCRIPTION
﻿Fix two bugs:

1. InvalidCastException when selecting Platform/AppType in ComboBox
   - Config.Platform was int, ComboBox.ItemsSource was PlatformItem[] → type mismatch
   - Changed to PlatformItem/AppTypeItem records with default values

2. Missing default selection and layout
   - Platform defaults to 'Windows', AppType defaults to 'ClientApp'
   - AppSecret + ProductID moved to same row for cleaner 2-column layout
   - SelectedIndex=0 ensures ComboBox shows default

Build: 0 errors
