### PR TITLE
fix: ComboBox default selection - use collection item reference

### DIFF
--- a/src/ViewModels/SimulateViewModel.cs
+++ b/src/ViewModels/SimulateViewModel.cs
@@ -36,6 +36,8 @@ public partial class SimulateViewModel : ViewModelBase
     public SimulateViewModel()
     {
         _status = _loc["Patch.Ready"];
+        Config.Platform = Platforms[0];
+        Config.AppType = AppTypes[0];
     }
 
     async Task<string?> PickFolder(string title)

--- a/src/Views/SimulateView.axaml
+++ b/src/Views/SimulateView.axaml
@@ -38,12 +38,10 @@
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
                         <TextBlock Grid.Column="0" Text="Platform" VerticalAlignment="Center"/>
                         <ComboBox Grid.Column="1" ItemsSource="{Binding Platforms}"
-                                  SelectedItem="{Binding Config.Platform}" Margin="8,0,16,0"
-                                  SelectedIndex="0"/>
+                                  SelectedItem="{Binding Config.Platform}" Margin="8,0,16,0"/>
                         <TextBlock Grid.Column="2" Text="AppType" VerticalAlignment="Center"/>
                         <ComboBox Grid.Column="3" ItemsSource="{Binding AppTypes}"
-                                  SelectedItem="{Binding Config.AppType}" Margin="8,0"
-                                  SelectedIndex="0"/>
+                                  SelectedItem="{Binding Config.AppType}" Margin="8,0"/>
                     </Grid>
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
                         <TextBlock Grid.Column="0" Text="AppSecret" VerticalAlignment="Center"/>


### PR DESCRIPTION
﻿Fix: ComboBox default selection error.

Root cause: Config.Platform was initialized as new PlatformItem(1,Windows) in the model, but Avalonia's ComboBox uses reference equality to find the selected item in ItemsSource. Even though PlatformItem is a record with value equality, the ComboBox couldn't match them.

Fix:
- Set Config.Platform = Platforms[0] and Config.AppType = AppTypes[0] in ViewModel constructor - these ARE the collection items
- Removed SelectedIndex=0 from XAML which conflicted with SelectedItem binding

Build: 0 errors
