### PR TITLE
fix: ClientGeneratorService string.Format template brace escaping

### DIFF
--- a/src/Services/ClientGeneratorService.cs
+++ b/src/Services/ClientGeneratorService.cs
@@ -20,7 +20,7 @@ using GeneralUpdate.ClientCore;
 using GeneralUpdate.Common.Shared.Object;
 using GeneralUpdate.Common.Internal.Event;
 
-var log = (string msg) => Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {msg}");
+var log = (string msg) => Console.WriteLine($"[{{DateTime.Now:HH:mm:ss}}] {{msg}}");
 
 try
 {{
@@ -79,7 +79,7 @@ using GeneralUpdate.Core;
 using GeneralUpdate.Common.Shared;
 using GeneralUpdate.Common.Internal.Event;
 
-var log = (string msg) => Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {msg}");
+var log = (string msg) => Console.WriteLine($"[{{DateTime.Now:HH:mm:ss}}] {{msg}}");
 
 try
 {{


### PR DESCRIPTION
﻿ClientGeneratorService template uses string.Format with numbered placeholders.
C# interpolated strings inside the template had unescaped curly braces
that string.Format tried to parse as placeholders.

Fix: double-escape template curly braces so string.Format outputs
single braces in the generated .cs file.

Build: 0 errors
