### PR TITLE
fix: simulation UTF8 encoding, timeout, NuGet version

### DIFF
--- a/src/Services/ClientGeneratorService.cs
+++ b/src/Services/ClientGeneratorService.cs
@@ -13,8 +13,8 @@ namespace GeneralUpdate.Tools.Services;
 public class ClientGeneratorService
 {
     private const string ClientTemplate = """
-#r "nuget: GeneralUpdate.ClientCore, 10.*"
-#r "nuget: GeneralUpdate.Core, 10.*"
+#r "nuget: GeneralUpdate.ClientCore"
+#r "nuget: GeneralUpdate.Core"
 
 using GeneralUpdate.ClientCore;
 using GeneralUpdate.Common.Shared.Object;
@@ -72,8 +72,8 @@ catch (Exception ex)
 """;
 
     private const string UpgradeTemplate = """
-#r "nuget: GeneralUpdate.Core, 10.*"
-#r "nuget: GeneralUpdate.ClientCore, 10.*"
+#r "nuget: GeneralUpdate.Core"
+#r "nuget: GeneralUpdate.ClientCore"
 
 using GeneralUpdate.Core;
 using GeneralUpdate.Common.Shared;

--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -18,7 +18,7 @@ public class SimulationService
     private readonly ClientGeneratorService _generator = new();
     private readonly LocalUpdateServer _server = new();
     private readonly StringBuilder _fullLog = new();
-    private int _timeoutSeconds = 60;
+    private int _timeoutSeconds = 120;
 
     public IReadOnlyList<string> LogLines => _fullLog.ToString().Split('\n').ToList();
 
@@ -144,6 +144,8 @@ public class SimulationService
             WorkingDirectory = workDir,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            StandardOutputEncoding = System.Text.Encoding.UTF8,
+            StandardErrorEncoding = System.Text.Encoding.UTF8,
             UseShellExecute = false,
             CreateNoWindow = true
         };


### PR DESCRIPTION
﻿Three fixes:

1. UTF8 encoding on dotnet run process streams - fixes garbled Chinese output
2. Timeout increased from 60s to 120s for first-run NuGet package restore
3. Remove floating version from #r directives - dotnet run does not support version globs

Build: 0 errors
