### PR TITLE
fix: use specific NuGet version 10.4.6 in #r directives

### DIFF
--- a/src/Services/ClientGeneratorService.cs
+++ b/src/Services/ClientGeneratorService.cs
@@ -13,8 +13,8 @@ namespace GeneralUpdate.Tools.Services;
 public class ClientGeneratorService
 {
     private const string ClientTemplate = """
-#r "nuget: GeneralUpdate.ClientCore"
-#r "nuget: GeneralUpdate.Core"
+#r "nuget: GeneralUpdate.ClientCore, 10.4.6"
+#r "nuget: GeneralUpdate.Core, 10.4.6"
 
 using GeneralUpdate.ClientCore;
 using GeneralUpdate.Common.Shared.Object;
@@ -72,8 +72,8 @@ catch (Exception ex)
 """;
 
     private const string UpgradeTemplate = """
-#r "nuget: GeneralUpdate.Core"
-#r "nuget: GeneralUpdate.ClientCore"
+#r "nuget: GeneralUpdate.Core, 10.4.6"
+#r "nuget: GeneralUpdate.ClientCore, 10.4.6"
 
 using GeneralUpdate.Core;
 using GeneralUpdate.Common.Shared;


### PR DESCRIPTION
﻿Replace floating version (10.*) with exact version 10.4.6 in #r directives.

- GeneralUpdate.ClientCore 10.4.6
- GeneralUpdate.Core 10.4.6

Build: 0 errors
