### PR TITLE
fix: rename to .csx, use dotnet script

### DIFF
--- a/src/Services/ClientGeneratorService.cs
+++ b/src/Services/ClientGeneratorService.cs
@@ -14,7 +14,6 @@ public class ClientGeneratorService
 {
     private const string ClientTemplate = """
 #r "nuget:GeneralUpdate.ClientCore,10.4.6"
-#r "nuget:GeneralUpdate.Core,10.4.6"
 
 using GeneralUpdate.ClientCore;
 using GeneralUpdate.Common.Shared.Object;
@@ -73,7 +72,6 @@ catch (Exception ex)
 
     private const string UpgradeTemplate = """
 #r "nuget:GeneralUpdate.Core,10.4.6"
-#r "nuget:GeneralUpdate.ClientCore,10.4.6"
 
 using GeneralUpdate.Core;
 using GeneralUpdate.Common.Shared;

--- a/src/Services/ClientGeneratorService.cs
+++ b/src/Services/ClientGeneratorService.cs
@@ -7,8 +7,8 @@ using GeneralUpdate.Tools.Models;
 namespace GeneralUpdate.Tools.Services;
 
 /// <summary>
-/// Generates single-file client.cs and upgrade.cs for simulation,
-/// using dotnet run with #r directives (exact NuGet version).
+/// Generates single-file client.csx and upgrade.csx for simulation,
+/// using dotnet script with #r directives (exact NuGet version).
 /// </summary>
 public class ClientGeneratorService
 {
@@ -116,19 +116,19 @@ catch (Exception ex)
     {
         var serverUrl = $"http://127.0.0.1:{config.ServerPort}";
 
-        await File.WriteAllTextAsync(Path.Combine(outputDir, "client.cs"),
+        await File.WriteAllTextAsync(Path.Combine(outputDir, "client.csx"),
             string.Format(ClientTemplate,
                 EscapeForCSharp(config.AppDirectory),
                 serverUrl,
-                "upgrade.cs",
-                "client.cs",
+                "upgrade.csx",
+                "client.csx",
                 config.CurrentVersion,
                 "1.0.0.0",
                 config.ProductId,
                 config.AppSecretKey),
             Encoding.UTF8);
 
-        await File.WriteAllTextAsync(Path.Combine(outputDir, "upgrade.cs"),
+        await File.WriteAllTextAsync(Path.Combine(outputDir, "upgrade.csx"),
             string.Format(UpgradeTemplate,
                 EscapeForCSharp(config.AppDirectory)),
             Encoding.UTF8);

--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -57,14 +57,14 @@ public class SimulationService
             config.ServerPort = _server.Port;
 
             // 4. Generate client/upgrade scripts
-            Log("STEP 4: Generating client.cs and upgrade.cs", progress);
+            Log("STEP 4: Generating client.csx and upgrade.csx", progress);
             await _generator.GenerateAsync(config, config.OutputDirectory);
-            Log($"  client.cs → {config.OutputDirectory}", progress);
-            Log($"  upgrade.cs → {config.OutputDirectory}", progress);
+            Log($"  client.csx → {config.OutputDirectory}", progress);
+            Log($"  upgrade.csx → {config.OutputDirectory}", progress);
 
             // 5. Run client
-            Log("STEP 5: Running client (dotnet run client.cs)", progress);
-            var clientResult = await RunDotNetScript(config.OutputDirectory, "client.cs", ct);
+            Log("STEP 5: Running client (dotnet script client.csx)", progress);
+            var clientResult = await RunDotNetScript(config.OutputDirectory, "client.csx", ct);
             Log(clientResult.Output, progress);
 
             if (!clientResult.Success)
@@ -139,7 +139,7 @@ public class SimulationService
 
     private async Task<(bool Success, string Output)> RunDotNetScript(string workDir, string script, CancellationToken ct)
     {
-        var psi = new ProcessStartInfo("dotnet", $"run {script}")
+        var psi = new ProcessStartInfo("dotnet", $"script {script}")
         {
             WorkingDirectory = workDir,
             RedirectStandardOutput = true,


### PR DESCRIPTION
﻿Rename generated scripts from .cs to .csx (C# Script).
Run with dotnet script instead of dotnet run.

- client.csx + upgrade.csx (#r directives work in .csx)
- dotnet script client.csx (not dotnet run)

Note: requires dotnet-script tool:
  dotnet tool install -g dotnet-script

Build: 0 errors
