### PR TITLE
fix: detect update failure from client output (not just exit code)

### DIFF
--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -173,8 +173,12 @@ public class SimulationService
             return (false, output + "\n[TIMEOUT] Simulation exceeded time limit");
         }
 
+        // Also check output for error indicators (GeneralUpdate catches exceptions internally)
         await Task.WhenAll(readTask, errorTask);
-        return (p.ExitCode == 0, output.ToString());
+        var outputStr = output.ToString();
+        var hasError = outputStr.Contains("ERROR:") || outputStr.Contains("FATAL:") || outputStr.Contains("JsonException");
+
+        return (!hasError && p.ExitCode == 0, outputStr);
     }
 
     private void VerifyUpdateResult(SimulateConfigModel config, SimulationResult result)


### PR DESCRIPTION
- GeneralUpdate catches exceptions internally, exits with code 0
- Check output for ERROR:, FATAL:, JsonException keywords
- Report FAIL if error found in client output