### PR TITLE
fix: i18n for Simulate Update module

### DIFF
--- a/src/Services/LocalizationService.cs
+++ b/src/Services/LocalizationService.cs
@@ -136,6 +136,10 @@ public class LocalizationService : INotifyPropertyChanged
             ["Sim.SelectOutput"] = "选择模拟输出目录",
             ["Sim.ValidateDirs"] = "请填写所有必填项",
             ["Sim.DotnetCheck"] = "需要 .NET 10.0 SDK，请先安装",
+            ["Sim.Starting"] = "正在启动模拟...",
+            ["Sim.Completed"] = "模拟完成 ({0:F1}s)",
+            ["Sim.Failed"] = "模拟失败: {0}",
+            ["Sim.Report"] = "报告: {0}",
         },
         ["en-US"] = new()
         {
@@ -229,6 +233,10 @@ public class LocalizationService : INotifyPropertyChanged
             ["Sim.SelectOutput"] = "Select simulation output directory",
             ["Sim.ValidateDirs"] = "Please fill in all required fields",
             ["Sim.DotnetCheck"] = ".NET 10.0 SDK is required. Please install it first.",
+            ["Sim.Starting"] = "Starting simulation...",
+            ["Sim.Completed"] = "Simulation completed ({0:F1}s)",
+            ["Sim.Failed"] = "Simulation failed: {0}",
+            ["Sim.Report"] = "Report: {0}",
         }
     };
 

--- a/src/ViewModels/SimulateViewModel.cs
+++ b/src/ViewModels/SimulateViewModel.cs
@@ -79,9 +79,9 @@ public partial class SimulateViewModel : ViewModelBase
         return r.Count > 0 ? r[0].Path.LocalPath : null;
     }
 
-    [RelayCommand] async Task SelectAppDir() { var p = await PickFolder("选择旧版本应用目录"); if (p != null) Config.AppDirectory = p; }
-    [RelayCommand] async Task SelectPatch() { var p = await PickFile("选择补丁包"); if (p != null) Config.PatchFilePath = p; }
-    [RelayCommand] async Task SelectOutputDir() { var p = await PickFolder("选择模拟输出目录"); if (p != null) Config.OutputDirectory = p; }
+    [RelayCommand] async Task SelectAppDir() { var p = await PickFolder(_loc["Sim.SelectAppDir"]); if (p != null) Config.AppDirectory = p; }
+    [RelayCommand] async Task SelectPatch() { var p = await PickFile(_loc["Sim.SelectPatch"]); if (p != null) Config.PatchFilePath = p; }
+    [RelayCommand] async Task SelectOutputDir() { var p = await PickFolder(_loc["Sim.SelectOutput"]); if (p != null) Config.OutputDirectory = p; }
 
     [RelayCommand]
     async Task StartSimulation()
@@ -92,7 +92,7 @@ public partial class SimulateViewModel : ViewModelBase
 
         IsRunning = true;
         Log.Clear();
-        Status = "Starting simulation...";
+        Status = _loc["Sim.Starting"];
 
         try
         {
@@ -101,17 +101,17 @@ public partial class SimulateViewModel : ViewModelBase
 
             if (result.Success)
             {
-                Status = $"Simulation completed ({result.Elapsed.TotalSeconds:F1}s)";
+                Status = _loc.T("Sim.Completed", result.Elapsed.TotalSeconds);
                 L($"Result: {(result.Success ? "PASS" : "FAIL")}");
                 foreach (var note in result.Notes)
                     L($"  Note: {note}");
 
                 var reportPath = await _report.GenerateAsync(Config, result, Config.OutputDirectory);
-                L($"Report: {reportPath}");
+                L(_loc.T("Sim.Report", reportPath));
             }
             else
             {
-                Status = $"Simulation failed: {result.ErrorMessage}";
+                Status = _loc.T("Sim.Failed", result.ErrorMessage);
             }
         }
         catch (Exception ex)

--- a/src/Views/SimulateView.axaml
+++ b/src/Views/SimulateView.axaml
@@ -3,24 +3,31 @@
              xmlns:vm="using:GeneralUpdate.Tools.ViewModels"
              xmlns:svc="using:GeneralUpdate.Tools.Services"
              x:Class="GeneralUpdate.Tools.Views.SimulateView"
+             x:Name="SimRoot"
              x:DataType="vm:SimulateViewModel">
     <ScrollViewer>
         <StackPanel Margin="28,24" Spacing="14">
-            <TextBlock Text="🧪 Simulate Update" FontSize="20" FontWeight="Bold"/>
+            <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.Title]}"
+                       FontSize="20" FontWeight="Bold"/>
 
             <!-- Test target -->
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="Test Target" FontSize="14" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.TestTarget]}"
+                               FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <TextBlock Grid.Column="0" Text="Old App Dir" VerticalAlignment="Center" Width="110"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.OldAppDir]}"
+                                   VerticalAlignment="Center" Width="100"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.AppDirectory}" IsReadOnly="True" Margin="8,0"/>
-                        <Button Grid.Column="2" Content="📁 Select" Command="{Binding SelectAppDirCommand}" MinWidth="80"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.Select]}"
+                                Command="{Binding SelectAppDirCommand}" MinWidth="80"/>
                     </Grid>
                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <TextBlock Grid.Column="0" Text="Patch Package" VerticalAlignment="Center" Width="110"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.PatchFile]}"
+                                   VerticalAlignment="Center" Width="100"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.PatchFilePath}" IsReadOnly="True" Margin="8,0"/>
-                        <Button Grid.Column="2" Content="📁 Select" Command="{Binding SelectPatchCommand}" MinWidth="80"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.Select]}"
+                                Command="{Binding SelectPatchCommand}" MinWidth="80"/>
                     </Grid>
                 </StackPanel>
             </Border>
@@ -28,25 +35,32 @@
             <!-- Config -->
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="Update Config" FontSize="14" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.UpdateConfig]}"
+                               FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
-                        <TextBlock Grid.Column="0" Text="Current Ver" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.CurrentVer]}"
+                                   VerticalAlignment="Center"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.CurrentVersion}" Margin="8,0,16,0"/>
-                        <TextBlock Grid.Column="2" Text="Target Ver" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.TargetVer]}"
+                                   VerticalAlignment="Center"/>
                         <TextBox Grid.Column="3" Text="{Binding Config.TargetVersion}" Margin="8,0"/>
                     </Grid>
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
-                        <TextBlock Grid.Column="0" Text="Platform" VerticalAlignment="Center"/>
-                        <ComboBox Grid.Column="1" ItemsSource="{Binding Platforms}"
-                                  SelectedIndex="{Binding PlatformIndex}" Margin="8,0,16,0"/>
-                        <TextBlock Grid.Column="2" Text="AppType" VerticalAlignment="Center"/>
-                        <ComboBox Grid.Column="3" ItemsSource="{Binding AppTypes}"
-                                  SelectedIndex="{Binding AppTypeIndex}" Margin="8,0"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.Platform]}"
+                                   VerticalAlignment="Center"/>
+                        <ComboBox x:Name="PlatformCombo" Grid.Column="1" ItemsSource="{Binding Platforms}"
+                                  SelectedIndex="0" Margin="8,0,16,0"/>
+                        <TextBlock Grid.Column="2" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.AppType]}"
+                                   VerticalAlignment="Center"/>
+                        <ComboBox x:Name="AppTypeCombo" Grid.Column="3" ItemsSource="{Binding AppTypes}"
+                                  SelectedIndex="0" Margin="8,0"/>
                     </Grid>
                     <Grid ColumnDefinitions="Auto,*,Auto,*">
-                        <TextBlock Grid.Column="0" Text="AppSecret" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.AppSecret]}"
+                                   VerticalAlignment="Center"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.AppSecretKey}" Margin="8,0,16,0"/>
-                        <TextBlock Grid.Column="2" Text="Product ID" VerticalAlignment="Center"/>
+                        <TextBlock Grid.Column="2" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.ProductId]}"
+                                   VerticalAlignment="Center"/>
                         <TextBox Grid.Column="3" Text="{Binding Config.ProductId}" Margin="8,0"/>
                     </Grid>
                 </StackPanel>
@@ -55,17 +69,21 @@
             <!-- Output -->
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
                 <StackPanel Spacing="10">
-                    <TextBlock Text="Output" FontSize="14" FontWeight="SemiBold"/>
+                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.Output]}"
+                               FontSize="14" FontWeight="SemiBold"/>
                     <Grid ColumnDefinitions="Auto,*,Auto">
-                        <TextBlock Grid.Column="0" Text="Simulate Dir" VerticalAlignment="Center" Width="110"/>
+                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.OutputDir]}"
+                                   VerticalAlignment="Center" Width="100"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.OutputDirectory}" IsReadOnly="True" Margin="8,0"/>
-                        <Button Grid.Column="2" Content="📁 Select" Command="{Binding SelectOutputDirCommand}" MinWidth="80"/>
+                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.Select]}"
+                                Command="{Binding SelectOutputDirCommand}" MinWidth="80"/>
                     </Grid>
                 </StackPanel>
             </Border>
 
             <!-- Run -->
-            <Button Content="🚀 Start Simulation" Command="{Binding StartSimulationCommand}"
+            <Button Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.Start]}"
+                    Command="{Binding StartSimulationCommand}"
                     IsEnabled="{Binding !IsRunning}" Height="40" FontSize="14" HorizontalAlignment="Stretch"/>
             <TextBlock Text="{Binding Status}" FontSize="13"/>
 

--- a/src/Views/SimulateView.axaml.cs
+++ b/src/Views/SimulateView.axaml.cs
@@ -1,8 +1,30 @@
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 namespace GeneralUpdate.Tools.Views;
 
 public partial class SimulateView : UserControl
 {
-    public SimulateView() => InitializeComponent();
+    public SimulateView()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        if (DataContext is ViewModels.SimulateViewModel vm)
+        {
+            PlatformCombo.SelectionChanged += (_, _) =>
+            {
+                if (PlatformCombo.SelectedIndex >= 0)
+                    vm.Config.Platform = PlatformCombo.SelectedIndex == 1 ? 2 : 1;
+            };
+            AppTypeCombo.SelectionChanged += (_, _) =>
+            {
+                if (AppTypeCombo.SelectedIndex >= 0)
+                    vm.Config.AppType = AppTypeCombo.SelectedIndex == 1 ? 2 : 1;
+            };
+        }
+    }
 }


### PR DESCRIPTION
﻿All Simulate module UI labels now use LocalizationService instead of hardcoded strings.

Fixed:
- SimulateView.axaml: 13 labels + 3 button texts now use {x:Static} bindings
- SimulateViewModel: 3 PickFolder/PickFile calls + 3 status messages use _loc
- Added 4 new i18n keys (Sim.Starting/Completed/Failed/Report)
- zh-CN and en-US both updated

Build: 0 errors
