### PR TITLE
fix: client AppName upgrade.csx -> upgrade.bat (not executable)

### DIFF
--- a/src/Services/ClientGeneratorService.cs
+++ b/src/Services/ClientGeneratorService.cs
@@ -118,7 +118,7 @@ catch (Exception ex)
             string.Format(ClientTemplate,
                 EscapeForCSharp(config.AppDirectory),
                 serverUrl,
-                "upgrade.csx",
+                "upgrade.bat",
                 "client.csx",
                 config.CurrentVersion,
                 "1.0.0.0",
@@ -130,6 +130,10 @@ catch (Exception ex)
             string.Format(UpgradeTemplate,
                 EscapeForCSharp(config.AppDirectory)),
             Encoding.UTF8);
+
+        await File.WriteAllTextAsync(Path.Combine(outputDir, "upgrade.bat"),
+            "@echo off\r\ndotnet script upgrade.csx\r\n",
+            Encoding.ASCII);
     }
 
     private static string EscapeForCSharp(string s) =>


### PR DESCRIPTION
﻿Root cause: client tried Process.Start(upgrade.csx) but .csx is not executable on Windows.

Fix: generate upgrade.bat wrapper that calls dotnet script upgrade.csx. Client AppName changed to upgrade.bat.

Build: 0 errors
