### PR TITLE
feat: replace .csx with pre-compiled test_app .exe for simulation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Publish
+      - name: Publish Tools
         run: >
           dotnet publish src/GeneralUpdate.Tools.csproj
           -c Release -r win-x64
@@ -23,11 +23,31 @@ jobs:
           -p:IncludeAllContentForSelfExtract=true
           -o publish/win-x64
 
+      - name: Publish Client
+        run: >
+          dotnet publish test_app/Client/ClientSample.csproj
+          -c Release -r win-x64
+          -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained
+          -o publish/test_app/Client
+
+      - name: Publish Upgrade
+        run: >
+          dotnet publish test_app/Upgrade/UpgradeSample.csproj
+          -c Release -r win-x64
+          -p:PublishSingleFile=true -p:PublishTrimmed=true --self-contained
+          -o publish/test_app/Upgrade
+
+      - name: Copy test apps to Tools output
+        run: |
+          mkdir -p publish/win-x64/test_app
+          cp publish/test_app/Client/ClientSample.exe publish/win-x64/test_app/Client.exe
+          cp publish/test_app/Upgrade/UpgradeSample.exe publish/win-x64/test_app/Upgrade.exe
+
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: win-x64
-          path: publish/win-x64/GeneralUpdate.Tools.exe
+          path: publish/win-x64/
 
   build-linux:
     runs-on: ubuntu-latest
@@ -39,7 +59,7 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
-      - name: Publish
+      - name: Publish Tools
         run: >
           dotnet publish src/GeneralUpdate.Tools.csproj
           -c Release -r linux-x64
@@ -52,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: linux-x64
-          path: publish/linux-x64/GeneralUpdate.Tools
+          path: publish/linux-x64/
 
   release:
     needs: [build-windows, build-linux]
@@ -62,22 +82,19 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
 
-      - name: Show structure (debug)
-        run: find . -type f
-
       - name: Get timestamp
         id: ts
         run: echo "timestamp=$(date -u '+%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
 
-      - name: Build
+      - name: Package win
         working-directory: win-x64
-        run: zip ../GeneralUpdate.Tools_${{ steps.ts.outputs.timestamp }}_win-x64.zip *
+        run: zip ../GeneralUpdate.Tools_${{ steps.ts.outputs.timestamp }}_win-x64.zip -r *
 
-      - name: Build
+      - name: Package linux
         working-directory: linux-x64
         run: |
           chmod +x *
-          zip ../GeneralUpdate.Tools_${{ steps.ts.outputs.timestamp }}_linux-x64.zip *
+          zip ../GeneralUpdate.Tools_${{ steps.ts.outputs.timestamp }}_linux-x64.zip -r *
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -12,7 +12,6 @@ namespace GeneralUpdate.Tools.Services;
 
 public class SimulationService
 {
-    private readonly ClientGeneratorService _generator = new();
     private readonly LocalUpdateServer _server = new();
     private readonly StringBuilder _fullLog = new();
     private int _timeoutSeconds = 120;
@@ -35,11 +34,23 @@ public class SimulationService
             Log($"STEP 2: Preparing {config.OutputDirectory}", progress);
             Directory.CreateDirectory(config.OutputDirectory);
 
-            // 3. Generate scripts
-            Log("STEP 3: Generating client.csx and upgrade.csx", progress);
-            await _generator.GenerateAsync(config, config.OutputDirectory);
-            Log($"  client.csx → {config.OutputDirectory}", progress);
-            Log($"  upgrade.csx → {config.OutputDirectory}", progress);
+            // 3. Copy test app executables
+            Log("STEP 3: Copying test executables", progress);
+            var toolsDir = AppDomain.CurrentDomain.BaseDirectory;
+            var clientSrc = Path.Combine(toolsDir, "test_app", "Client.exe");
+            var upgradeSrc = Path.Combine(toolsDir, "test_app", "Upgrade.exe");
+
+            if (!File.Exists(clientSrc))
+                throw new FileNotFoundException($"Client.exe not found at {clientSrc}. Ensure test_app is deployed.");
+            if (!File.Exists(upgradeSrc))
+                throw new FileNotFoundException($"Upgrade.exe not found at {upgradeSrc}. Ensure test_app is deployed.");
+
+            var clientDest = Path.Combine(config.OutputDirectory, "Client.exe");
+            var upgradeDest = Path.Combine(config.OutputDirectory, "Upgrade.exe");
+            File.Copy(clientSrc, clientDest, true);
+            File.Copy(upgradeSrc, upgradeDest, true);
+            Log($"  Client.exe → {config.OutputDirectory}", progress);
+            Log($"  Upgrade.exe → {config.OutputDirectory}", progress);
 
             // 4. Start server
             Log("STEP 4: Starting local server", progress);
@@ -58,8 +69,10 @@ public class SimulationService
             config.ServerPort = _server.Port;
 
             // 5. Run client
-            Log("STEP 5: Running client (dotnet script client.csx)", progress);
-            var clientResult = await RunDotNetScript(config.OutputDirectory, "client.csx", ct);
+            Log("STEP 5: Running Client.exe", progress);
+            var clientExe = Path.Combine(config.OutputDirectory, "Client.exe");
+            var clientArgs = $"--server-url {_server.BaseUrl} --install-path \"{config.AppDirectory}\" --current-version {config.CurrentVersion} --app-secret {config.AppSecretKey} --product-id {config.ProductId} --app-name Upgrade.exe";
+            var clientResult = await RunExe(clientExe, clientArgs, ct);
             Log(clientResult.Output, progress);
 
             if (!clientResult.Success)
@@ -116,11 +129,10 @@ public class SimulationService
         catch { throw new InvalidOperationException("dotnet CLI not found"); }
     }
 
-    private async Task<(bool Success, string Output)> RunDotNetScript(string workDir, string script, CancellationToken ct)
+    private async Task<(bool Success, string Output)> RunExe(string exePath, string arguments, CancellationToken ct)
     {
-        var psi = new ProcessStartInfo("dotnet", $"script {script}")
+        var psi = new ProcessStartInfo(exePath, arguments)
         {
-            WorkingDirectory = workDir,
             RedirectStandardOutput = true, RedirectStandardError = true,
             StandardOutputEncoding = Encoding.UTF8, StandardErrorEncoding = Encoding.UTF8,
             UseShellExecute = false, CreateNoWindow = true

--- a/test_app/Client/ClientSample.csproj
+++ b/test_app/Client/ClientSample.csproj
@@ -1,30 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="build.bat" />
-    <None Remove="ClientSample.Desktop\**" />
-    <None Remove="ClientSample\**" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="GeneralUpdate.ClientCore" Version="10.4.6" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="ClientSample.Desktop\**" />
-    <Compile Remove="ClientSample\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Remove="ClientSample.Desktop\**" />
-    <EmbeddedResource Remove="ClientSample\**" />
-  </ItemGroup>
-
 </Project>

--- a/test_app/Client/Program.cs
+++ b/test_app/Client/Program.cs
@@ -1,104 +1,90 @@
-﻿using System.Text;
+using System.Diagnostics;
 using GeneralUpdate.ClientCore;
 using GeneralUpdate.Common.Download;
 using GeneralUpdate.Common.Internal;
 using GeneralUpdate.Common.Internal.Bootstrap;
 using GeneralUpdate.Common.Shared.Object;
 
+// Parse command-line arguments
+var cliArgs = ParseArgs(args);
+
+Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Client started");
+Console.WriteLine($"Install path: {cliArgs.InstallPath}");
+
+var configinfo = new Configinfo
+{
+    ReportUrl = $"{cliArgs.ServerUrl}/Upgrade/Report",
+    UpdateUrl = $"{cliArgs.ServerUrl}/Upgrade/Verification",
+    AppName = cliArgs.AppName,
+    MainAppName = AppDomain.CurrentDomain.FriendlyName,
+    InstallPath = cliArgs.InstallPath,
+    ClientVersion = cliArgs.CurrentVersion,
+    UpgradeClientVersion = "1.0.0.0",
+    ProductId = cliArgs.ProductId,
+    AppSecretKey = cliArgs.AppSecret,
+};
+
 try
 {
-    Console.WriteLine($"主程序初始化，{DateTime.Now}！");
-    Console.WriteLine("当前运行目录：" + Thread.GetDomain().BaseDirectory);
-    var configinfo = new Configinfo
-    {
-        //UpdateLogUrl = "https://www.baidu.com",
-        ReportUrl = "http://127.0.0.1:5000/Upgrade/Report",
-        UpdateUrl = "http://127.0.0.1:5000/Upgrade/Verification",
-        AppName = "UpgradeSample.exe",
-        MainAppName = "ClientSample.exe",
-        InstallPath = Thread.GetDomain().BaseDirectory,
-        //Bowl = "Generalupdate.CatBowl.exe",
-        //当前客户端的版本号
-        ClientVersion = "1.0.0.0",
-        //当前升级端的版本号
-        UpgradeClientVersion = "1.0.0.0",
-        //产品id
-        ProductId = "2d974e2a-31e6-4887-9bb1-b4689e98c77a",
-        //应用密钥
-        AppSecretKey = "dfeb5833-975e-4afb-88f1-6278ee9aeff6",
-        //BlackFiles = new List<string> { "123.exe" },
-        //BlackFormats = new List<string> { "123.dll" },
-        //SkipDirectorys = new List<string> { "logs" },
-        //Scheme = "Bearer",
-        //Token = "..."
-    };
-    _ = await new GeneralClientBootstrap()
-        //单个或多个更新包下载速度、剩余下载事件、当前下载版本信息通知事件
-        .AddListenerMultiDownloadStatistics(OnMultiDownloadStatistics)
-        //单个或多个更新包下载完成
-        .AddListenerMultiDownloadCompleted(OnMultiDownloadCompleted)
-        //完成所有的下载任务通知
-        .AddListenerMultiAllDownloadCompleted(OnMultiAllDownloadCompleted)
-        //下载过程出现的异常通知
-        .AddListenerMultiDownloadError(OnMultiDownloadError)
-        //整个更新过程出现的任何问题都会通过这个事件通知
-        .AddListenerException(OnException)
-        //服务端返回更新信息后的通知（可用于显示更新日志、版本信息等）
-        .AddListenerUpdateInfo(OnUpdateInfo)
-        //更新预检回调：返回 true 跳过本次更新，返回 false 继续自动更新
-        //（强制更新版本会忽略此回调）
-        .AddListenerUpdatePrecheck(OnUpdatePrecheck)
+    await new GeneralClientBootstrap()
+        .AddListenerMultiDownloadStatistics((_, e) =>
+        {
+            var v = e.Version as VersionInfo;
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Download: {v?.Version} {e.ProgressPercentage}%");
+        })
+        .AddListenerMultiAllDownloadCompleted((_, e) =>
+        {
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] All downloads: {(e.IsAllDownloadCompleted ? "completed" : $"failed ({e.FailedVersions.Count})")}");
+        })
+        .AddListenerMultiDownloadCompleted((_, e) =>
+        {
+            var v = e.Version as VersionInfo;
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Download {v?.Version}: {(e.IsComplated ? "done" : "failed")}");
+        })
+        .AddListenerException((_, e) =>
+        {
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] ERROR: {e.Exception}");
+        })
+        .AddListenerUpdateInfo((_, e) =>
+        {
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Update info: Code={e.Info.Code}, Versions={e.Info.Body?.Count ?? 0}");
+        })
         .SetConfig(configinfo)
         .Option(UpdateOption.DownloadTimeOut, 60)
-        .Option(UpdateOption.Encoding, Encoding.Default)
         .LaunchAsync();
-    Console.WriteLine($"主程序已启动，{DateTime.Now}！");
-    await Task.Delay(2000);
+
+    Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Client completed successfully");
 }
-catch (Exception e)
+catch (Exception ex)
 {
-    Console.WriteLine(e.Message + "\n" + e.StackTrace);
+    Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] FATAL: {ex.Message}");
+    Environment.Exit(1);
 }
 
-void OnMultiDownloadError(object arg1, MultiDownloadErrorEventArgs arg2)
+static ClientArgs ParseArgs(string[] argv)
 {
-    var version = arg2.Version as VersionInfo;
-    Console.WriteLine($"{version?.Version} {arg2.Exception}");
+    var a = new ClientArgs();
+    for (int i = 0; i < argv.Length; i++)
+    {
+        switch (argv[i])
+        {
+            case "--server-url" when i + 1 < argv.Length: a.ServerUrl = argv[++i]; break;
+            case "--install-path" when i + 1 < argv.Length: a.InstallPath = argv[++i]; break;
+            case "--current-version" when i + 1 < argv.Length: a.CurrentVersion = argv[++i]; break;
+            case "--app-secret" when i + 1 < argv.Length: a.AppSecret = argv[++i]; break;
+            case "--product-id" when i + 1 < argv.Length: a.ProductId = argv[++i]; break;
+            case "--app-name" when i + 1 < argv.Length: a.AppName = argv[++i]; break;
+        }
+    }
+    return a;
 }
 
-void OnMultiAllDownloadCompleted(object arg1, MultiAllDownloadCompletedEventArgs arg2)
+class ClientArgs
 {
-    Console.WriteLine(arg2.IsAllDownloadCompleted ? "所有的下载任务已完成！" : $"下载任务已失败！{arg2.FailedVersions.Count}");
-}
-
-void OnMultiDownloadCompleted(object arg1, MultiDownloadCompletedEventArgs arg2)
-{
-    var version = arg2.Version as VersionInfo;
-    Console.WriteLine(arg2.IsComplated ? $"当前下载版本：{version?.Version}, 下载完成！" : $"当前下载版本：{version?.Version}, 下载失败！");
-}
-
-void OnMultiDownloadStatistics(object arg1, MultiDownloadStatisticsEventArgs arg2)
-{
-    var version = arg2.Version as VersionInfo;
-    Console.WriteLine(
-        $"当前下载版本：{version?.Version}，下载速度：{arg2.Speed}，剩余下载时间：{arg2.Remaining}，已下载大小：{arg2.BytesReceived}，总大小：{arg2.TotalBytesToReceive}, 进度百分比：{arg2.ProgressPercentage}%");
-}
-
-void OnException(object arg1, ExceptionEventArgs arg2)
-{
-    Console.WriteLine($"{arg2.Exception}");
-}
-
-void OnUpdateInfo(object arg1, UpdateInfoEventArgs arg2)
-{
-    // arg2.Info 包含服务端返回的完整版本信息（VersionRespDTO）
-    Console.WriteLine($"服务端返回更新信息：Code={arg2.Info.Code}, 版本数量={arg2.Info.Body?.Count ?? 0}");
-}
-
-bool OnUpdatePrecheck(UpdateInfoEventArgs arg)
-{
-    // 返回 true：跳过本次更新；返回 false：继续执行自动更新
-    // 可在此处添加自定义判断逻辑，例如检查磁盘空间、询问用户是否立即更新等
-    Console.WriteLine($"更新预检：发现 {arg.Info.Body?.Count ?? 0} 个可用版本，继续更新...");
-    return false; // false = 继续更新
+    public string ServerUrl { get; set; } = "http://127.0.0.1:5000";
+    public string InstallPath { get; set; } = AppDomain.CurrentDomain.BaseDirectory;
+    public string CurrentVersion { get; set; } = "1.0.0.0";
+    public string AppSecret { get; set; } = "dfeb5833-975e-4afb-88f1-6278ee9aeff6";
+    public string ProductId { get; set; } = "2d974e2a-31e6-4887-9bb1-b4689e98c77a";
+    public string AppName { get; set; } = "Upgrade.exe";
 }

--- a/test_app/Upgrade/Program.cs
+++ b/test_app/Upgrade/Program.cs
@@ -1,60 +1,89 @@
-﻿using GeneralUpdate.Common.Download;
-using GeneralUpdate.Common.Internal;
-using GeneralUpdate.Common.Shared.Object;
+using System.Text.Json;
 using GeneralUpdate.Core;
+
+// Parse command-line args
+var cliArgs = ParseArgs(Environment.GetCommandLineArgs()[1..]);
+
+// Write ProcessInfo as env var for GeneralUpdateBootstrap
+var processInfoJson = JsonSerializer.Serialize(new Dictionary<string, object>
+{
+    ["AppName"] = "Client.exe",
+    ["InstallPath"] = cliArgs.InstallPath,
+    ["CurrentVersion"] = cliArgs.CurrentVersion,
+    ["LastVersion"] = cliArgs.LastVersion,
+    ["CompressEncoding"] = "utf-8",
+    ["CompressFormat"] = ".zip",
+    ["DownloadTimeOut"] = 60,
+    ["AppSecretKey"] = cliArgs.AppSecret,
+    ["UpdateVersions"] = new[]
+    {
+        new Dictionary<string, object?>
+        {
+            ["Name"] = cliArgs.PatchName,
+            ["Version"] = cliArgs.TargetVersion,
+            ["Hash"] = cliArgs.Hash,
+            ["AppType"] = 1,
+            ["IsForcibly"] = false
+        }
+    }
+});
+
+Environment.SetEnvironmentVariable("ProcessInfo", processInfoJson);
+
+Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Upgrade started");
+Console.WriteLine($"Install path: {cliArgs.InstallPath}");
 
 try
 {
-    Console.WriteLine($"升级程序初始化，{DateTime.Now}！");
-    Console.WriteLine("当前运行目录：" + Thread.GetDomain().BaseDirectory);
-    _ = await new GeneralUpdateBootstrap()
-        //单个或多个更新包下载速度、剩余下载事件、当前下载版本信息通知事件
-        .AddListenerMultiDownloadStatistics(OnMultiDownloadStatistics)
-        //单个或多个更新包下载完成
-        .AddListenerMultiDownloadCompleted(OnMultiDownloadCompleted)
-        //完成所有的下载任务通知
-        .AddListenerMultiAllDownloadCompleted(OnMultiAllDownloadCompleted)
-        //下载过程出现的异常通知
-        .AddListenerMultiDownloadError(OnMultiDownloadError)
-        //整个更新过程出现的任何问题都会通过这个事件通知
-        .AddListenerException(OnException)
-        //设置字段映射表，用于解析所有驱动包的信息的字符串
-        //.SetFieldMappings(fieldMappingsCN)
-        //是否开启驱动更新
-        //.Option(UpdateOption.Drive, true)
+    await new GeneralUpdateBootstrap()
+        .AddListenerMultiDownloadStatistics((_, e) =>
+        {
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Download: {e.ProgressPercentage}%");
+        })
+        .AddListenerMultiAllDownloadCompleted((_, e) =>
+        {
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Downloads: {(e.IsAllDownloadCompleted ? "done" : "failed")}");
+        })
+        .AddListenerException((_, e) =>
+        {
+            Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] ERROR: {e.Exception}");
+        })
         .LaunchAsync();
-    Console.WriteLine($"升级程序已启动，{DateTime.Now}！");
-    await Task.Delay(2000);
+
+    Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] Upgrade completed");
 }
-catch (Exception e)
+catch (Exception ex)
 {
-    Console.WriteLine(e.Message + "\n" + e.StackTrace);
+    Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] FATAL: {ex.Message}");
+    Environment.Exit(1);
 }
 
-void OnMultiDownloadError(object arg1, MultiDownloadErrorEventArgs arg2)
+static UpgradeArgs ParseArgs(string[] argv)
 {
-    var version = arg2.Version as VersionInfo;
-    Console.WriteLine($"{version?.Version} {arg2.Exception}");
+    var a = new UpgradeArgs();
+    for (int i = 0; i < argv.Length; i++)
+    {
+        switch (argv[i])
+        {
+            case "--install-path" when i + 1 < argv.Length: a.InstallPath = argv[++i]; break;
+            case "--current-version" when i + 1 < argv.Length: a.CurrentVersion = argv[++i]; break;
+            case "--target-version" when i + 1 < argv.Length: a.TargetVersion = argv[++i]; break;
+            case "--last-version" when i + 1 < argv.Length: a.LastVersion = argv[++i]; break;
+            case "--app-secret" when i + 1 < argv.Length: a.AppSecret = argv[++i]; break;
+            case "--patch-name" when i + 1 < argv.Length: a.PatchName = argv[++i]; break;
+            case "--hash" when i + 1 < argv.Length: a.Hash = argv[++i]; break;
+        }
+    }
+    return a;
 }
 
-void OnMultiAllDownloadCompleted(object arg1, MultiAllDownloadCompletedEventArgs arg2)
+class UpgradeArgs
 {
-    Console.WriteLine(arg2.IsAllDownloadCompleted ? "所有的下载任务已完成！" : $"下载任务已失败！{arg2.FailedVersions.Count}");
-}
-
-void OnMultiDownloadCompleted(object arg1, MultiDownloadCompletedEventArgs arg2)
-{
-    var version = arg2.Version as VersionInfo;
-    Console.WriteLine(arg2.IsComplated ? $"当前下载版本：{version?.Version}, 下载完成！" : $"当前下载版本：{version?.Version}, 下载失败！");
-}
-
-void OnMultiDownloadStatistics(object arg1, MultiDownloadStatisticsEventArgs arg2)
-{
-    var version = arg2.Version as VersionInfo;
-    Console.WriteLine($"当前下载版本：{version?.Version}，下载速度：{arg2.Speed}，剩余下载时间：{arg2.Remaining}，已下载大小：{arg2.BytesReceived}，总大小：{arg2.TotalBytesToReceive}, 进度百分比：{arg2.ProgressPercentage}%");
-}
-
-void OnException(object arg1, ExceptionEventArgs arg2)
-{
-    Console.WriteLine($"{arg2.Exception}");
+    public string InstallPath { get; set; } = AppDomain.CurrentDomain.BaseDirectory;
+    public string CurrentVersion { get; set; } = "1.0.0.0";
+    public string TargetVersion { get; set; } = "2.0.0.0";
+    public string LastVersion { get; set; } = "1.0.0.0";
+    public string AppSecret { get; set; } = "";
+    public string PatchName { get; set; } = "";
+    public string Hash { get; set; } = "";
 }

--- a/test_app/Upgrade/UpgradeSample.csproj
+++ b/test_app/Upgrade/UpgradeSample.csproj
@@ -1,30 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="build.bat" />
-    <None Remove="UpgradeSample.Desktop\**" />
-    <None Remove="UpgradeSample\**" />
-  </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="GeneralUpdate.Core" Version="10.4.6" />
   </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="UpgradeSample.Desktop\**" />
-    <Compile Remove="UpgradeSample\**" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Remove="UpgradeSample.Desktop\**" />
-    <EmbeddedResource Remove="UpgradeSample\**" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
﻿Replace .csx script generation with pre-compiled .exe test apps.

- test_app/Client/Client.exe: accepts --server-url --install-path --current-version --app-secret --product-id --app-name
- test_app/Upgrade/Upgrade.exe: accepts --install-path --current-version --target-version --app-secret --patch-name --hash
- CI publishes both as single-file .exe into Tools output/test_app/
- Simulate module copies .exe to output dir, runs Client.exe with args
- Removes ClientGeneratorService usage from SimulationService

Build: 0 errors
