### PR TITLE
fix: copy Upgrade.exe to app install directory

### DIFF
--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -60,11 +60,14 @@ public class SimulationService
             await DotNetPublishAsync(upgradeProj, exeDir);
             Log($"  Upgrade.exe → {exeDir}", progress);
 
-            // Copy to simulation output
+            // Copy to simulation output AND install path (GeneralUpdate StartApp looks here)
             var clientDest = Path.Combine(config.OutputDirectory, "Client.exe");
-            var upgradeDest = Path.Combine(config.OutputDirectory, "Upgrade.exe");
             File.Copy(Path.Combine(exeDir, "ClientSample.exe"), clientDest, true);
-            File.Copy(Path.Combine(exeDir, "UpgradeSample.exe"), upgradeDest, true);
+
+            var upgradeExe = Path.Combine(exeDir, "UpgradeSample.exe");
+            File.Copy(upgradeExe, Path.Combine(config.OutputDirectory, "Upgrade.exe"), true);
+            File.Copy(upgradeExe, Path.Combine(config.AppDirectory, "Upgrade.exe"), true);
+            Log($"  Upgrade.exe → {config.AppDirectory}", progress);
 
             // 4. Start server
             Log("STEP 4: Starting local server", progress);


### PR DESCRIPTION
﻿GeneralUpdate.StartApp looks for Upgrade.exe in InstallPath (old app directory), not simulation output.
