### PR TITLE
refactor: remove OutputDirectory — run simulation entirely in AppDirectory

### DIFF
--- a/src/Models/SimulateConfigModel.cs
+++ b/src/Models/SimulateConfigModel.cs
@@ -15,6 +15,5 @@ public partial class SimulateConfigModel : ObservableObject
     [ObservableProperty] private int _appType = 1;
     [ObservableProperty] private string _appSecretKey = "dfeb5833-975e-4afb-88f1-6278ee9aeff6";
     [ObservableProperty] private string _productId = "2d974e2a-31e6-4887-9bb1-b4689e98c77a";
-    [ObservableProperty] private string _outputDirectory = string.Empty;
     public int ServerPort { get; set; } = 5000;
 }

--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -30,9 +30,9 @@ public class SimulationService
             Log("STEP 1: Validating inputs", progress);
             Validate(config);
 
-            // 2. Prepare output
-            Log($"STEP 2: Preparing {config.OutputDirectory}", progress);
-            Directory.CreateDirectory(config.OutputDirectory);
+            // 2. Prepare app directory
+            Log($"STEP 2: Preparing {config.AppDirectory}", progress);
+            Directory.CreateDirectory(config.AppDirectory);
 
             // 3. Compile test apps to .exe
             Log("STEP 3: Compiling test apps", progress);
@@ -60,18 +60,17 @@ public class SimulationService
             await DotNetPublishAsync(upgradeProj, exeDir);
             Log($"  Upgrade.exe → {exeDir}", progress);
 
-            // Copy to simulation output AND install path (GeneralUpdate StartApp looks here)
-            var clientDest = Path.Combine(config.OutputDirectory, "Client.exe");
+            // Copy compiled apps into app directory (where the update will run)
+            var clientDest = Path.Combine(config.AppDirectory, "Client.exe");
             File.Copy(Path.Combine(exeDir, "ClientSample.exe"), clientDest, true);
 
             var upgradeExe = Path.Combine(exeDir, "UpgradeSample.exe");
-            File.Copy(upgradeExe, Path.Combine(config.OutputDirectory, "Upgrade.exe"), true);
             File.Copy(upgradeExe, Path.Combine(config.AppDirectory, "Upgrade.exe"), true);
             Log($"  Upgrade.exe → {config.AppDirectory}", progress);
 
             // 4. Start server
             Log("STEP 4: Starting local server", progress);
-            var serverPatchDir = Path.Combine(config.OutputDirectory, ".server");
+            var serverPatchDir = Path.Combine(config.AppDirectory, ".server");
             Directory.CreateDirectory(serverPatchDir);
             var patchName = Path.GetFileName(config.PatchFilePath);
             var patchDest = Path.Combine(serverPatchDir, patchName);
@@ -87,11 +86,11 @@ public class SimulationService
 
             // 5. Run client
             Log("STEP 5: Running Client.exe", progress);
-            var clientExe = Path.Combine(config.OutputDirectory, "Client.exe");
+            var clientExe = Path.Combine(config.AppDirectory, "Client.exe");
             var clientArgs = new List<string>
             {
                 "--server-url", _server.BaseUrl,
-                "--install-path", config.OutputDirectory,
+                "--install-path", config.AppDirectory,
                 "--current-version", config.CurrentVersion,
                 "--app-secret", config.AppSecretKey,
                 "--product-id", config.ProductId,
@@ -160,8 +159,6 @@ public class SimulationService
             throw new DirectoryNotFoundException($"App directory not found: {config.AppDirectory}");
         if (!File.Exists(config.PatchFilePath))
             throw new FileNotFoundException($"Patch file not found: {config.PatchFilePath}");
-        if (string.IsNullOrWhiteSpace(config.OutputDirectory))
-            throw new ArgumentException("Output directory is required");
         try
         {
             var psi = new ProcessStartInfo("dotnet", "--version") { RedirectStandardOutput = true, UseShellExecute = false, CreateNoWindow = true };

--- a/src/ViewModels/SimulateViewModel.cs
+++ b/src/ViewModels/SimulateViewModel.cs
@@ -83,14 +83,12 @@ public partial class SimulateViewModel : ViewModelBase
 
     [RelayCommand] async Task SelectAppDir() { var p = await PickFolder(_loc["Sim.SelectAppDir"]); if (p != null) Config.AppDirectory = p; }
     [RelayCommand] async Task SelectPatch() { var p = await PickFile(_loc["Sim.SelectPatch"]); if (p != null) Config.PatchFilePath = p; }
-    [RelayCommand] async Task SelectOutputDir() { var p = await PickFolder(_loc["Sim.SelectOutput"]); if (p != null) Config.OutputDirectory = p; }
 
     [RelayCommand]
     async Task StartSimulation()
     {
         if (string.IsNullOrWhiteSpace(Config.AppDirectory)) { Status = _loc["Sim.ValidateDirs"]; return; }
         if (string.IsNullOrWhiteSpace(Config.PatchFilePath)) { Status = _loc["Sim.ValidateDirs"]; return; }
-        if (string.IsNullOrWhiteSpace(Config.OutputDirectory)) { Status = _loc["Sim.ValidateDirs"]; return; }
 
         IsRunning = true; StartButtonText = "⏳ Running..."; Log.Clear(); Status = _loc["Sim.Starting"];
         try
@@ -107,7 +105,7 @@ public partial class SimulateViewModel : ViewModelBase
             }
             L($"Result: {(result.Success ? "PASS" : "FAIL")}");
             foreach (var note in result.Notes) L($"  Note: {note}");
-            var reportPath = await _report.GenerateAsync(Config, result, Config.OutputDirectory);
+            var reportPath = await _report.GenerateAsync(Config, result, Config.AppDirectory);
             L(_loc.T("Sim.Report", reportPath));
         }
         catch (Exception ex)
@@ -115,7 +113,7 @@ public partial class SimulateViewModel : ViewModelBase
             Status = $"Error: {ex.Message}";
             L($"FATAL: {ex}");
             var failResult = new SimulationResult { Success = false, ErrorMessage = ex.Message };
-            var reportPath = await _report.GenerateAsync(Config, failResult, Config.OutputDirectory);
+            var reportPath = await _report.GenerateAsync(Config, failResult, Config.AppDirectory);
             L(_loc.T("Sim.Report", reportPath));
         }
         finally { IsRunning = false; StartButtonText = _loc["Sim.Start"]; }

--- a/src/Views/SimulateView.axaml
+++ b/src/Views/SimulateView.axaml
@@ -66,21 +66,6 @@
                 </StackPanel>
             </Border>
 
-            <!-- Output -->
-            <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
-                <StackPanel Spacing="10">
-                    <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.Output]}"
-                               FontSize="14" FontWeight="SemiBold"/>
-                    <Grid ColumnDefinitions="Auto,*,Auto">
-                        <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.OutputDir]}"
-                                   VerticalAlignment="Center" Width="100"/>
-                        <TextBox Grid.Column="1" Text="{Binding Config.OutputDirectory}" IsReadOnly="True" Margin="8,0"/>
-                        <Button Grid.Column="2" Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Sim.Select]}"
-                                Command="{Binding SelectOutputDirCommand}" MinWidth="80"/>
-                    </Grid>
-                </StackPanel>
-            </Border>
-
             <!-- Run -->
             <Button Content="{Binding StartButtonText}"
                     Command="{Binding StartSimulationCommand}"


### PR DESCRIPTION
## Problem

PR #66 partially addressed the path issue but the OutputDirectory concept remained. The simulation still required a separate output directory, while the user wants everything to happen inside AppDirectory (the target update path).

## Solution

Remove the OutputDirectory concept entirely.

| File | Change |
|------|--------|
| SimulateConfigModel.cs | Remove _outputDirectory property |
| SimulationService.cs | All OutputDirectory → AppDirectory; remove validation |
| SimulateViewModel.cs | Remove SelectOutputDirCommand; report → AppDirectory |
| SimulateView.axaml | Remove Output directory UI section |

## Result

Everything runs in AppDirectory: Client.exe, Upgrade.exe, .server/, simulation_report.md.