### PR TITLE
feat: skip recompilation on cached test apps + bundle in CI release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,11 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Build test apps (Client + Upgrade)
+        run: |
+          dotnet publish test_app/Client/ClientSample.csproj -c Release -r win-x64 -p:PublishSingleFile=true --self-contained -o prebuilt
+          dotnet publish test_app/Upgrade/UpgradeSample.csproj -c Release -r win-x64 -p:PublishSingleFile=true --self-contained -o prebuilt
+
       - name: Publish Tools
         run: >
           dotnet publish src/GeneralUpdate.Tools.csproj
@@ -22,6 +27,9 @@ jobs:
           -p:IncludeNativeLibrariesForSelfExtract=true
           -p:IncludeAllContentForSelfExtract=true
           -o publish/win-x64
+
+      - name: Copy test apps into publish output
+        run: xcopy prebuilt\* publish\win-x64\test_app_exe\ /Y /I
 
       - name: Upload
         uses: actions/upload-artifact@v4
@@ -39,6 +47,11 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Build test apps (Client + Upgrade)
+        run: |
+          dotnet publish test_app/Client/ClientSample.csproj -c Release -r linux-x64 -p:PublishSingleFile=true --self-contained -o prebuilt
+          dotnet publish test_app/Upgrade/UpgradeSample.csproj -c Release -r linux-x64 -p:PublishSingleFile=true --self-contained -o prebuilt
+
       - name: Publish Tools
         run: >
           dotnet publish src/GeneralUpdate.Tools.csproj
@@ -47,6 +60,9 @@ jobs:
           -p:IncludeNativeLibrariesForSelfExtract=true
           -p:IncludeAllContentForSelfExtract=true
           -o publish/linux-x64
+
+      - name: Copy test apps into publish output
+        run: mkdir -p publish/linux-x64/test_app_exe && cp prebuilt/* publish/linux-x64/test_app_exe/
 
       - name: Upload
         uses: actions/upload-artifact@v4

--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -34,39 +34,55 @@ public class SimulationService
             Log($"STEP 2: Preparing {config.AppDirectory}", progress);
             Directory.CreateDirectory(config.AppDirectory);
 
-            // 3. Compile test apps to .exe
-            Log("STEP 3: Compiling test apps", progress);
+            // 3. Ensure test apps are available
+            Log("STEP 3: Preparing test apps", progress);
             var toolsDir = AppDomain.CurrentDomain.BaseDirectory;
-            var clientProj = Path.Combine(toolsDir, "..", "..", "..", "..", "test_app", "Client", "ClientSample.csproj");
-            var upgradeProj = Path.Combine(toolsDir, "..", "..", "..", "..", "test_app", "Upgrade", "UpgradeSample.csproj");
-
-            // Normalize paths
-            clientProj = Path.GetFullPath(clientProj);
-            upgradeProj = Path.GetFullPath(upgradeProj);
-
-            if (!File.Exists(clientProj))
-                throw new FileNotFoundException($"Client project not found at {clientProj}");
-            if (!File.Exists(upgradeProj))
-                throw new FileNotFoundException($"Upgrade project not found at {upgradeProj}");
-
-            var exeDir = Path.Combine(toolsDir, "test_app");
-            Directory.CreateDirectory(exeDir);
-
-            Log("  Compiling Client.exe...", progress);
-            await DotNetPublishAsync(clientProj, exeDir);
-            Log($"  Client.exe → {exeDir}", progress);
-
-            Log("  Compiling Upgrade.exe...", progress);
-            await DotNetPublishAsync(upgradeProj, exeDir);
-            Log($"  Upgrade.exe → {exeDir}", progress);
-
-            // Copy compiled apps into app directory (where the update will run)
             var clientDest = Path.Combine(config.AppDirectory, "Client.exe");
-            File.Copy(Path.Combine(exeDir, "ClientSample.exe"), clientDest, true);
+            var upgradeDest = Path.Combine(config.AppDirectory, "Upgrade.exe");
 
-            var upgradeExe = Path.Combine(exeDir, "UpgradeSample.exe");
-            File.Copy(upgradeExe, Path.Combine(config.AppDirectory, "Upgrade.exe"), true);
-            Log($"  Upgrade.exe → {config.AppDirectory}", progress);
+            if (File.Exists(clientDest) && File.Exists(upgradeDest))
+            {
+                Log("  Test apps already cached, skipping", progress);
+            }
+            else
+            {
+                // Strategy 1: bundled exes (release package)
+                var bundledDir = Path.Combine(toolsDir, "test_app_exe");
+                if (Directory.Exists(bundledDir) &&
+                    File.Exists(Path.Combine(bundledDir, "ClientSample.exe")) &&
+                    File.Exists(Path.Combine(bundledDir, "UpgradeSample.exe")))
+                {
+                    Log("  Copying bundled test apps...", progress);
+                    File.Copy(Path.Combine(bundledDir, "ClientSample.exe"), clientDest, true);
+                    File.Copy(Path.Combine(bundledDir, "UpgradeSample.exe"), upgradeDest, true);
+                    Log($"  Client.exe → {config.AppDirectory}", progress);
+                    Log($"  Upgrade.exe → {config.AppDirectory}", progress);
+                }
+                else
+                {
+                    // Strategy 2: compile from source (dev environment)
+                    var clientProj = Path.GetFullPath(Path.Combine(toolsDir, "..", "..", "..", "..", "test_app", "Client", "ClientSample.csproj"));
+                    var upgradeProj = Path.GetFullPath(Path.Combine(toolsDir, "..", "..", "..", "..", "test_app", "Upgrade", "UpgradeSample.csproj"));
+
+                    if (!File.Exists(clientProj) || !File.Exists(upgradeProj))
+                        throw new FileNotFoundException("Test apps not found. Run in dev environment or use a release build that includes test_app_exe.");
+
+                    var exeDir = Path.Combine(toolsDir, "test_app");
+                    Directory.CreateDirectory(exeDir);
+
+                    Log("  Compiling Client.exe...", progress);
+                    await DotNetPublishAsync(clientProj, exeDir);
+                    Log($"  Client.exe → {exeDir}", progress);
+
+                    Log("  Compiling Upgrade.exe...", progress);
+                    await DotNetPublishAsync(upgradeProj, exeDir);
+                    Log($"  Upgrade.exe → {exeDir}", progress);
+
+                    File.Copy(Path.Combine(exeDir, "ClientSample.exe"), clientDest, true);
+                    File.Copy(Path.Combine(exeDir, "UpgradeSample.exe"), upgradeDest, true);
+                    Log($"  Copied to {config.AppDirectory}", progress);
+                }
+            }
 
             // 4. Start server
             Log("STEP 4: Starting local server", progress);


### PR DESCRIPTION
## Changes

### 1. Skip recompilation when test apps already cached

SimulationService Step 3 now uses a three-tier strategy:

| Priority | Strategy | When |
|----------|----------|------|
| 1 | Cache hit | Client.exe + Upgrade.exe already exist in AppDirectory → skip |
| 2 | Release bundle | test_app_exe/ directory found next to tools → copy pre-built |
| 3 | Dev compile | Source code (csproj) available → dotnet publish |

This means repeated simulation runs don't recompile test apps every time.

### 2. Bundle test apps in CI release package

publish.yml now compiles ClientSample.exe and UpgradeSample.exe during the build and copies them into publish/{rid}/test_app_exe/. The released zip includes:

\\\
GeneralUpdate.Tools.exe
test_app_exe/
├── ClientSample.exe
└── UpgradeSample.exe
\\\

Users can run simulations without .NET SDK or source code — the tools copy the pre-built exes from test_app_exe/ to the target AppDirectory.