### PR TITLE
fix: find bundled test_app_exe from exe directory, not BaseDirectory

### DIFF
--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -47,7 +47,9 @@ public class SimulationService
             else
             {
                 // Strategy 1: bundled exes (release package)
-                var bundledDir = Path.Combine(toolsDir, "test_app_exe");
+                // Use ProcessPath not BaseDirectory — single-file publish extracts to a temp dir
+                var appRoot = Path.GetDirectoryName(Environment.ProcessPath)!;
+                var bundledDir = Path.Combine(appRoot, "test_app_exe");
                 if (Directory.Exists(bundledDir) &&
                     File.Exists(Path.Combine(bundledDir, "ClientSample.exe")) &&
                     File.Exists(Path.Combine(bundledDir, "UpgradeSample.exe")))


### PR DESCRIPTION
## Problem

PublishSingleFile=true extracts the .NET runtime to a temp directory at startup. AppDomain.CurrentDomain.BaseDirectory points to that temp dir, not where GeneralUpdate.Tools.exe and test_app_exe/ actually live.

Result from user test:
```
[17:53:51] STEP 3: Preparing test apps
[17:53:51] Simulation failed: Test apps not found.
```

## Fix

Use Environment.ProcessPath to find the real exe directory for bundled test app lookup. toolsDir (BaseDirectory) is still used for the dev-mode source compilation fallback — that path is relative to the project output, not the single-file bundle.

Single line change, SimulationService.cs line 51-52.
