### PR TITLE
fix: 统一 SemVer 2.0 版本标准并修复配置生成默认值与进度提示

### DIFF
--- a/src/Models/ConfigGeneratorModel.cs
+++ b/src/Models/ConfigGeneratorModel.cs
@@ -11,12 +11,13 @@ public partial class ConfigGeneratorModel : ObservableObject
     // ── Analysis state ──
     [ObservableProperty] private bool _isAnalyzed;
     [ObservableProperty] private bool _isAnalyzing;
+    [ObservableProperty] private bool _isPublishing;
 
     // ── Editable fields (auto-filled + user input) ──
     [ObservableProperty] private string _mainAppName = "";
-    [ObservableProperty] private string _clientVersion = "";
+    [ObservableProperty] private string _clientVersion = "1.0.0";
     [ObservableProperty] private string _updateAppName = "Update.exe";
-    [ObservableProperty] private string _upgradeClientVersion = "";
+    [ObservableProperty] private string _upgradeClientVersion = "1.0.0";
     [ObservableProperty] private string _appType = "Client";
     [ObservableProperty] private string _productId = "";
     [ObservableProperty] private string _updatePath = "update/";

--- a/src/Models/ManifestModel.cs
+++ b/src/Models/ManifestModel.cs
@@ -3,10 +3,10 @@ namespace GeneralUpdate.Tools.Models;
 public class ManifestModel
 {
     public string MainAppName { get; set; } = "";
-    public string ClientVersion { get; set; } = "";
+    public string ClientVersion { get; set; } = "1.0.0";
     public string AppType { get; set; } = "Client";
     public string UpdateAppName { get; set; } = "Update.exe";
-    public string UpgradeClientVersion { get; set; } = "";
+    public string UpgradeClientVersion { get; set; } = "1.0.0";
     public string ProductId { get; set; } = "";
     public string UpdatePath { get; set; } = "update/";
 }

--- a/src/Services/LocalUpdateServer.cs
+++ b/src/Services/LocalUpdateServer.cs
@@ -78,13 +78,12 @@ public class LocalUpdateServer : IAsyncDisposable
                         !string.Equals(v.ProductId, productId, StringComparison.OrdinalIgnoreCase))
                         return false;
                     // Version filter: only return versions higher than client's.
-                    // Exclude unparseable versions — silently including them
-                    // would defeat the update-loop guard.
-                    if (!Version.TryParse(v.TargetVersion, out var itemVer)) return false;
-                    if (!Version.TryParse(clientVersion, out var clientVer)) return false;
-                    return itemVer > clientVer;
+                    // Uses SemVer 2.0 comparison — unparseable versions are silently skipped.
+                    if (!SemverValidator.IsValid(v.TargetVersion)) return false;
+                    if (!SemverValidator.IsValid(clientVersion)) return false;
+                    return SemverValidator.Compare(v.TargetVersion, clientVersion) > 0;
                 })
-                .OrderByDescending(v => Version.TryParse(v.TargetVersion, out var ver) ? ver : new Version(0, 0))
+                .OrderByDescending(v => SemverValidator.IsValid(v.TargetVersion) ? SemverValidator.ParseCore(v.TargetVersion) : (0, 0, 0))
                 .ToList();
 
             if (matches.Count == 0)

--- a/src/Services/ManifestGeneratorService.cs
+++ b/src/Services/ManifestGeneratorService.cs
@@ -34,14 +34,14 @@ public static class ManifestGeneratorService
             MainAppName = !string.IsNullOrWhiteSpace(userInput?.MainAppName)
                 ? userInput.MainAppName
                 : client.AssemblyName,
-            ClientVersion = userInput?.ClientVersion ?? "",
+            ClientVersion = userInput?.ClientVersion ?? "1.0.0",
             AppType = !string.IsNullOrWhiteSpace(userInput?.AppType)
                 ? userInput.AppType
                 : "Client",
             UpdateAppName = !string.IsNullOrWhiteSpace(userInput?.UpdateAppName)
                 ? userInput.UpdateAppName
                 : upgrade?.AssemblyName ?? "Update.exe",
-            UpgradeClientVersion = userInput?.UpgradeClientVersion ?? "",
+            UpgradeClientVersion = userInput?.UpgradeClientVersion ?? "1.0.0",
             ProductId = userInput?.ProductId ?? "",
             UpdatePath = !string.IsNullOrWhiteSpace(userInput?.UpdatePath)
                 ? userInput.UpdatePath

--- a/src/Services/SemverValidator.cs
+++ b/src/Services/SemverValidator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Text.RegularExpressions;
 
 namespace GeneralUpdate.Tools.Services;
@@ -13,5 +14,77 @@ public static partial class SemverValidator
         RegexOptions.Compiled)]
     private static partial Regex SemverRegex();
 
+    // Captures: 1=MAJOR, 2=MINOR, 3=PATCH, 4=pre-release (including leading '-'), 5=build (including leading '+')
+    [GeneratedRegex(
+        @"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$",
+        RegexOptions.Compiled)]
+    private static partial Regex SemverPartsRegex();
+
     public static bool IsValid(string version) => SemverRegex().IsMatch(version);
+
+    /// <summary>
+    ///     Extract the numeric (MAJOR, MINOR, PATCH) core for sorting.
+    ///     Returns (0,0,0) if the version cannot be parsed.
+    /// </summary>
+    public static (int Major, int Minor, int Patch) ParseCore(string version)
+    {
+        var m = SemverPartsRegex().Match(version);
+        if (!m.Success) return (0, 0, 0);
+        return (int.Parse(m.Groups[1].Value), int.Parse(m.Groups[2].Value), int.Parse(m.Groups[3].Value));
+    }
+
+    /// <summary>
+    ///     Compare two SemVer 2.0 version strings.
+    ///     Returns negative if <paramref name="a"/> &lt; <paramref name="b"/>,
+    ///     zero if equal, positive if <paramref name="a"/> &gt; <paramref name="b"/>.
+    /// </summary>
+    public static int Compare(string a, string b)
+    {
+        var ma = SemverPartsRegex().Match(a);
+        var mb = SemverPartsRegex().Match(b);
+        if (!ma.Success || !mb.Success)
+            throw new ArgumentException("Both versions must be valid SemVer 2.0.");
+
+        // Compare MAJOR.MINOR.PATCH numerically
+        for (int i = 1; i <= 3; i++)
+        {
+            var cmp = int.Parse(ma.Groups[i].Value).CompareTo(int.Parse(mb.Groups[i].Value));
+            if (cmp != 0) return cmp;
+        }
+
+        // Pre-release comparison
+        // A version without pre-release has higher precedence than one with pre-release
+        var preA = ma.Groups[5].Value; // Group 5 = pre-release identifiers (without leading '-')
+        var preB = mb.Groups[5].Value;
+        var hasPreA = !string.IsNullOrEmpty(preA);
+        var hasPreB = !string.IsNullOrEmpty(preB);
+
+        if (!hasPreA && !hasPreB) return 0;
+        if (!hasPreA && hasPreB) return 1;
+        if (hasPreA && !hasPreB) return -1;
+
+        // Both have pre-release — compare identifiers
+        var idsA = preA.Split('.');
+        var idsB = preB.Split('.');
+        var count = Math.Min(idsA.Length, idsB.Length);
+        for (int i = 0; i < count; i++)
+        {
+            var cmp = ComparePreReleaseIdentifier(idsA[i], idsB[i]);
+            if (cmp != 0) return cmp;
+        }
+
+        // All compared identifiers equal — longer pre-release has higher precedence
+        return idsA.Length.CompareTo(idsB.Length);
+    }
+
+    private static int ComparePreReleaseIdentifier(string a, string b)
+    {
+        var numA = int.TryParse(a, out var nA);
+        var numB = int.TryParse(b, out var nB);
+
+        if (numA && numB) return nA.CompareTo(nB);       // both numeric
+        if (numA && !numB) return -1;                     // numeric < alphanumeric
+        if (!numA && numB) return 1;                      // alphanumeric > numeric
+        return string.CompareOrdinal(a, b);               // both alphanumeric
+    }
 }

--- a/src/Services/SimulationService.cs
+++ b/src/Services/SimulationService.cs
@@ -73,7 +73,7 @@ public class SimulationService
                 ClientVersion = config.CurrentVersion,
                 AppType = config.AppType switch { 1 => "Client", 2 => "Upgrade", _ => "Client" },
                 UpdateAppName = upgradeExeName,
-                UpgradeClientVersion = "1.0.0.0",
+                UpgradeClientVersion = "1.0.0",
                 ProductId = config.ProductId,
                 UpdatePath = config.UpdatePath ?? "update/"
             };

--- a/src/ViewModels/ConfigViewModel.cs
+++ b/src/ViewModels/ConfigViewModel.cs
@@ -19,9 +19,16 @@ public partial class ConfigViewModel : ViewModelBase
     public ConfigGeneratorModel Model { get; } = new();
     public List<string> AppTypes { get; } = new() { "Client", "Upgrade", "OssClient", "OssUpgrade" };
 
+    public bool IsBusy => Model.IsAnalyzing || Model.IsPublishing;
+
     public ConfigViewModel()
     {
-        Model.PropertyChanged += (_, _) => UpdatePreview();
+        Model.PropertyChanged += (_, e) =>
+        {
+            UpdatePreview();
+            if (e.PropertyName is nameof(ConfigGeneratorModel.IsAnalyzing) or nameof(ConfigGeneratorModel.IsPublishing))
+                OnPropertyChanged(nameof(IsBusy));
+        };
     }
 
     private static Avalonia.Controls.TopLevel? GetTopLevel()
@@ -209,7 +216,7 @@ public partial class ConfigViewModel : ViewModelBase
             return;
         }
 
-        Model.IsAnalyzing = true;
+        Model.IsPublishing = true;
         Model.StatusText = _loc["Config.Publishing"];
 
         try
@@ -263,7 +270,7 @@ public partial class ConfigViewModel : ViewModelBase
         }
         finally
         {
-            Model.IsAnalyzing = false;
+            Model.IsPublishing = false;
         }
     }
 

--- a/src/Views/ConfigView.axaml
+++ b/src/Views/ConfigView.axaml
@@ -113,10 +113,22 @@
             <!-- Action buttons -->
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
                 <Button Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Config.Generate]}"
-                        Command="{Binding GenerateCommand}" MinWidth="140"/>
+                        Command="{Binding GenerateCommand}" MinWidth="140"
+                        IsEnabled="{Binding IsBusy, Converter={x:Static BoolConverters.Not}}"/>
                 <Button Content="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Config.GenerateSample]}"
-                        Command="{Binding GenerateSampleCommand}" MinWidth="160"/>
+                        Command="{Binding GenerateSampleCommand}" MinWidth="160"
+                        IsEnabled="{Binding IsBusy, Converter={x:Static BoolConverters.Not}}"/>
             </StackPanel>
+
+            <!-- Progress (visible during analysis / publishing) -->
+            <Border Padding="16,12" CornerRadius="8" IsVisible="{Binding IsBusy}"
+                    Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">
+                <StackPanel Spacing="10">
+                    <ProgressBar IsIndeterminate="True" Height="8"/>
+                    <TextBlock Text="{Binding Model.StatusText}" FontSize="14" FontWeight="SemiBold"
+                               HorizontalAlignment="Center" TextWrapping="Wrap"/>
+                </StackPanel>
+            </Border>
 
             <!-- Preview -->
             <Border Padding="16" CornerRadius="8" Background="{DynamicResource SystemControlBackgroundChromeMediumBrush}">

--- a/src/Views/ExtensionView.axaml
+++ b/src/Views/ExtensionView.axaml
@@ -17,7 +17,7 @@
                         <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Name]}" VerticalAlignment="Center"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.Name}" PlaceholderText="MyExtension" Margin="8,0,16,0"/>
                         <TextBlock Grid.Column="2" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Version]}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="3" Text="{Binding Config.Version}" PlaceholderText="1.0.0.0" Margin="8,0"/>
+                        <TextBox Grid.Column="3" Text="{Binding Config.Version}" PlaceholderText="1.0.0 (semver)" Margin="8,0"/>
                     </Grid>
                     <TextBlock Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.Description]}"/>
                     <TextBox Text="{Binding Config.Description}" PlaceholderText="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Ext.DescPlaceholder]}"

--- a/src/Views/PatchView.axaml
+++ b/src/Views/PatchView.axaml
@@ -42,7 +42,7 @@
                         <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.PackageName]}" VerticalAlignment="Center"/>
                         <TextBox Grid.Column="1" Text="{Binding Config.PackageName}" PlaceholderText="patch_v1.0_to_v1.1" Margin="8,0,16,0"/>
                         <TextBlock Grid.Column="2" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.Version]}" VerticalAlignment="Center"/>
-                        <TextBox Grid.Column="3" Text="{Binding Config.Version}" PlaceholderText="1.0.0.0" Margin="8,0"/>
+                        <TextBox Grid.Column="3" Text="{Binding Config.Version}" PlaceholderText="1.0.0 (semver)" Margin="8,0"/>
                     </Grid>
                     <Grid ColumnDefinitions="Auto,*,Auto,Auto">
                         <TextBlock Grid.Column="0" Text="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[Patch.OutputDir]}" VerticalAlignment="Center"/>


### PR DESCRIPTION
## 修复内容

### SemVer 2.0 一致性 (Closes #79)

| 问题 | 修复 |
|------|------|
| `ConfigGeneratorModel` 版本默认值为 `""` | 改为 `"1.0.0"` |
| `ManifestModel` 版本默认值为 `""` | 改为 `"1.0.0"` |
| `SimulationService` 硬编码 `"1.0.0.0"`（4段非 SemVer） | 改为 `"1.0.0"` |
| `PatchView.axaml` / `ExtensionView.axaml` Placeholder `"1.0.0.0"` | 改为 `"1.0.0 (semver)"` |
| `LocalUpdateServer` 使用 `System.Version.TryParse` 比较版本 | 改用 `SemverValidator.Compare` + `ParseCore` |
| `SemverValidator` 缺少比较方法 | 新增 `Compare()`（含预发布版本优先级）和 `ParseCore()` |
| `ManifestGeneratorService.FromCsprojInfo` fallback 为 `""` | 改为 `"1.0.0"` |

### 进度提示改进

- ✅ 操作按钮下方新增 **ProgressBar + 加粗状态文字**（`IsBusy` 时自动显示）
- ✅ "生成"/"生成示例"按钮在操作期间**自动禁用**，防止重复点击
- ✅ 新增 `_isPublishing` 状态区分"分析"和"发布示例"操作
- ✅ 无需滚动即可看到进度反馈

### 修改文件（10个）
```
src/Models/ConfigGeneratorModel.cs
src/Models/ManifestModel.cs
src/Services/SemverValidator.cs
src/Services/LocalUpdateServer.cs
src/Services/ManifestGeneratorService.cs
src/Services/SimulationService.cs
src/ViewModels/ConfigViewModel.cs
src/Views/ConfigView.axaml
src/Views/ExtensionView.axaml
src/Views/PatchView.axaml
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)