### PR TITLE
feat: Lingua i18n 多语言框架源码集成

### DIFF
--- a/src/App.axaml.cs
+++ b/src/App.axaml.cs
@@ -4,9 +4,14 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using Avalonia.Metadata;
 using GeneralUpdate.Tools.Configuration;
 using GeneralUpdate.Tools.ViewModels;
 using GeneralUpdate.Tools.Views;
+
+// Register Lingua markup extensions under Avalonia's default XAML namespace
+// so that {Translate} and {FormatTranslate} work without an extra xmlns import.
+[assembly: XmlnsDefinition("https://github.com/avaloniaui", "Irihi.Lingua")]
 
 namespace GeneralUpdate.Tools;
 
@@ -23,6 +28,9 @@ public partial class App : Application
         {
             // Load translations from embedded JSON files (must be after platform init)
             Services.LocalizationService.Instance.LoadFromResources();
+
+            // Initialize Lingua — must be after LocalizationService is loaded
+            _ = Irihi.Lingua.AppLanguageManager.Instance;
 
             // Initialize configuration (synchronous path for startup reliability)
             var config = LoadConfigSafe();

--- a/src/Lingua/AppLanguageManager.cs
+++ b/src/Lingua/AppLanguageManager.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Globalization;
+using GeneralUpdate.Tools.Services;
+
+namespace Irihi.Lingua;
+
+/// <summary>
+/// Concrete Lingua language manager for GeneralUpdate.Tools.
+/// Loads resources from the existing <see cref="LocalizationService"/> JSON files
+/// and bridges reactive culture switching with the legacy localization system.
+///
+/// Usage:
+/// <code>
+/// // Switch language (updates both Lingua observables AND legacy bindings)
+/// AppLanguageManager.Instance.UpdateCulture(new CultureInfo("zh-CN"));
+///
+/// // Reactive access
+/// var title = AppLanguageManager.Instance.App_Title;
+/// title.Subscribe(t => Console.WriteLine(t));
+///
+/// // XAML with TranslateExtension
+/// &lt;TextBlock Text="{Translate {x:Static lingua:AppLanguageManager+Keys.App_Title}}" /&gt;
+/// </code>
+/// </summary>
+[LinguaManager("./Resources/Locales")]
+public sealed class AppLanguageManager : LanguageManager
+{
+    public static new AppLanguageManager Instance { get; } = new();
+
+    private AppLanguageManager() : base("zh-CN")
+    {
+        // Load all resources from existing LocalizationService
+        LoadFromLocalizationService();
+
+        // Set initial culture
+        UpdateCulture(new CultureInfo(LocalizationService.Instance.Locale));
+
+        // Listen for legacy locale changes and sync back to Lingua
+        LocalizationService.Instance.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(LocalizationService.Locale))
+                UpdateCulture(new CultureInfo(LocalizationService.Instance.Locale));
+        };
+    }
+
+    private void LoadFromLocalizationService()
+    {
+        var loc = LocalizationService.Instance;
+
+        // Register zh-CN from the loaded JSON or fallback dictionary
+        AddResources(new CultureInfo("zh-CN"), loc.GetAllStrings("zh-CN"));
+
+        // Register en-US
+        AddResources(new CultureInfo("en-US"), loc.GetAllStrings("en-US"));
+    }
+
+    // ── Strongly-typed observable properties ─────────────────
+    //     Only the most commonly used keys are exposed as properties.
+    //     All other keys are accessible via GetObservable("Key.Name").
+
+    public IObservable<string?> App_Title         => GetObservable("App.Title");
+    public IObservable<string?> Nav_Patch         => GetObservable("Nav.Patch");
+    public IObservable<string?> Nav_Extension     => GetObservable("Nav.Extension");
+    public IObservable<string?> Nav_OSS           => GetObservable("Nav.OSS");
+    public IObservable<string?> Nav_Simulate      => GetObservable("Nav.Simulate");
+    public IObservable<string?> Nav_Config        => GetObservable("Nav.Config");
+    public IObservable<string?> Nav_Settings      => GetObservable("Nav.Settings");
+    public IObservable<string?> Patch_Title       => GetObservable("Patch.Title");
+    public IObservable<string?> Patch_Build       => GetObservable("Patch.Build");
+
+    /// <summary>
+    /// Gets the current translation for a key (synchronous, non-observable).
+    /// </summary>
+    public string this[string key] => Resolve(key) ?? key;
+
+    // ── Keys class (mirrors source-generator output) ─────────
+
+    /// <summary>
+    /// Strongly-typed keys for use with <see cref="TranslateExtension"/> in XAML.
+    /// Usage: <c>{Translate {x:Static lingua:AppLanguageManager+Keys.App_Title}}</c>
+    /// </summary>
+    public static class Keys
+    {
+        public static LinguaKey App_Title         => new("App.Title", Instance);
+        public static LinguaKey Nav_Patch         => new("Nav.Patch", Instance);
+        public static LinguaKey Nav_Extension     => new("Nav.Extension", Instance);
+        public static LinguaKey Nav_OSS           => new("Nav.OSS", Instance);
+        public static LinguaKey Nav_Simulate      => new("Nav.Simulate", Instance);
+        public static LinguaKey Nav_Config        => new("Nav.Config", Instance);
+        public static LinguaKey Nav_Settings      => new("Nav.Settings", Instance);
+        public static LinguaKey Patch_Title       => new("Patch.Title", Instance);
+        public static LinguaKey Patch_OldDir      => new("Patch.OldDir", Instance);
+        public static LinguaKey Patch_NewDir      => new("Patch.NewDir", Instance);
+        public static LinguaKey Patch_Build       => new("Patch.Build", Instance);
+        public static LinguaKey Patch_PackageInfo => new("Patch.PackageInfo", Instance);
+        public static LinguaKey Patch_OutputDir   => new("Patch.OutputDir", Instance);
+        public static LinguaKey Patch_Select      => new("Patch.Select", Instance);
+        public static LinguaKey Ext_Title         => new("Ext.Title", Instance);
+        public static LinguaKey OSS_Title         => new("OSS.Title", Instance);
+        public static LinguaKey Sim_Title         => new("Sim.Title", Instance);
+        public static LinguaKey Config_Title      => new("Config.Title", Instance);
+        public static LinguaKey Settings_UploadSection => new("Settings.UploadSection", Instance);
+        public static LinguaKey Settings_Save     => new("Settings.Save", Instance);
+        public static LinguaKey Settings_Reset    => new("Settings.Reset", Instance);
+        public static LinguaKey Upload_Success    => new("Upload.Success", Instance);
+        public static LinguaKey Upload_Failed     => new("Upload.Failed", Instance);
+    }
+}

--- a/src/Lingua/FormatTranslateExtension.cs
+++ b/src/Lingua/FormatTranslateExtension.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using global::Avalonia;
+using global::Avalonia.Data;
+using global::Avalonia.Data.Converters;
+using global::Avalonia.Markup.Xaml;
+
+namespace Irihi.Lingua;
+
+/// <summary>
+/// Avalonia markup extension for format strings with localized arguments.
+///
+/// Usage in XAML:
+/// <code>
+/// &lt;TextBlock&gt;
+///     &lt;TextBlock.Text&gt;
+///         &lt;FormatTranslate FormatKey="{x:Static local:LanguageManager+Keys.Page_Template}"&gt;
+///             &lt;TranslateEntry Binding="{Binding #page.Value}" /&gt;
+///             &lt;TranslateEntry Key="{x:Static local:LanguageManager+Keys.Greeting_Message}" /&gt;
+///         &lt;/FormatTranslate&gt;
+///     &lt;/TextBlock.Text&gt;
+/// &lt;/TextBlock&gt;
+/// </code>
+/// </summary>
+public sealed class FormatTranslateExtension : MarkupExtension
+{
+    public LinguaKey? FormatKey { get; set; }
+    public IList<TranslateEntry> Items { get; set; } = new List<TranslateEntry>();
+
+    public FormatTranslateExtension() { }
+
+    public override object ProvideValue(IServiceProvider serviceProvider)
+    {
+        if (FormatKey == null)
+            return AvaloniaProperty.UnsetValue;
+
+        var converter = new FormatTranslateConverter();
+        var formatObservable = FormatKey.Manager.GetObservable(FormatKey.Key);
+        var formatSource = new LinguaBindingSource(formatObservable);
+
+        // Build a MultiBinding with the format template and all arguments
+        var multiBinding = new MultiBinding
+        {
+            Converter = converter,
+            Mode = BindingMode.OneWay,
+        };
+
+        // Bind to the format template
+        multiBinding.Bindings.Add(new Binding
+        {
+            Source = formatSource,
+            Path = "Value",
+            Mode = BindingMode.OneWay,
+        });
+
+        // Add each argument binding
+        foreach (var item in Items)
+        {
+            if (item.Key != null)
+            {
+                var argObservable = item.Key.Manager.GetObservable(item.Key.Key);
+                var argSource = new LinguaBindingSource(argObservable);
+                multiBinding.Bindings.Add(new Binding
+                {
+                    Source = argSource,
+                    Path = "Value",
+                    Mode = BindingMode.OneWay,
+                });
+            }
+            else if (item.Binding != null)
+            {
+                multiBinding.Bindings.Add(item.Binding);
+            }
+        }
+
+        // Return the MultiBinding directly — Avalonia will apply it
+        return multiBinding;
+    }
+}
+
+/// <summary>
+/// An entry in a <see cref="FormatTranslateExtension"/> — either a localized key
+/// or a standard Avalonia binding.
+/// </summary>
+public sealed class TranslateEntry
+{
+    public LinguaKey? Key { get; set; }
+    public BindingBase? Binding { get; set; }
+
+    public TranslateEntry() { }
+}
+
+/// <summary>
+/// Multi-value converter for format strings. The first value is the format template;
+/// remaining values are the format arguments.
+/// </summary>
+public sealed class FormatTranslateConverter : IMultiValueConverter
+{
+    public object? Convert(IList<object?> values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Count == 0)
+            return AvaloniaProperty.UnsetValue;
+
+        var format = values[0] as string;
+        if (string.IsNullOrEmpty(format))
+            return AvaloniaProperty.UnsetValue;
+
+        var args = new object?[values.Count - 1];
+        for (var i = 1; i < values.Count; i++)
+            args[i - 1] = values[i];
+
+        return string.Format(format, args);
+    }
+}

--- a/src/Lingua/ILinguaManager.cs
+++ b/src/Lingua/ILinguaManager.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace Irihi.Lingua;
+
+/// <summary>
+/// Interface implemented by all Lingua language managers.
+/// Provides culture switching and reactive observable access to localized strings.
+/// </summary>
+public interface ILinguaManager
+{
+    /// <summary>Switch the active culture and push new values to all subscribers.</summary>
+    void UpdateCulture(CultureInfo culture);
+
+    /// <summary>Get an observable that emits when the given key's translation changes.</summary>
+    IObservable<string?> GetObservable(string key);
+
+    /// <summary>Register resource strings for a specific culture at runtime.</summary>
+    void AddResources(CultureInfo culture, IReadOnlyDictionary<string, string> resources);
+}

--- a/src/Lingua/LanguageManager.cs
+++ b/src/Lingua/LanguageManager.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Irihi.Lingua;
+
+/// <summary>
+/// Base class for Lingua language managers. Concrete managers extend this
+/// to expose strongly-typed <see cref="IObservable{T}"/> properties for each resource key.
+///
+/// Usage:
+/// <code>
+/// public sealed class AppLanguageManager : LanguageManager
+/// {
+///     public static new AppLanguageManager Instance { get; } = new();
+///     public IObservable&lt;string?&gt; App_Title => GetObservable("App.Title");
+/// }
+/// </code>
+/// </summary>
+public abstract class LanguageManager : ILinguaManager
+{
+    private readonly Dictionary<string, LinguaObservableString> _observables = new();
+    private readonly LinguaRuntimeResources _resources;
+    private CultureInfo _currentCulture = CultureInfo.InvariantCulture;
+
+    protected LanguageManager(string invariantCultureName = "")
+    {
+        _resources = new LinguaRuntimeResources(invariantCultureName);
+    }
+
+    // ── ILinguaManager ───────────────────────────────────────
+
+    /// <inheritdoc />
+    public void UpdateCulture(CultureInfo culture)
+    {
+        _currentCulture = culture;
+        var resolved = _resources.Resolve(culture);
+
+        // Push updated values to all observables
+        foreach (var kvp in _observables)
+        {
+            var key = kvp.Key;
+            var observable = kvp.Value;
+            var newValue = resolved.TryGetValue(key, out var val) ? val : null;
+            observable.OnNext(newValue);
+        }
+    }
+
+    /// <inheritdoc />
+    public IObservable<string?> GetObservable(string key)
+    {
+        if (_observables.TryGetValue(key, out var existing))
+            return existing;
+
+        // Look up current value from resolved resources
+        var resolved = _resources.Resolve(_currentCulture);
+        var initialValue = resolved.TryGetValue(key, out var val) ? val : null;
+
+        var observable = new LinguaObservableString(key, initialValue);
+        _observables[key] = observable;
+        return observable;
+    }
+
+    /// <inheritdoc />
+    public void AddResources(CultureInfo culture, IReadOnlyDictionary<string, string> resources)
+    {
+        _resources.Add(culture, resources);
+
+        // If we're adding resources for the current culture, push updates
+        if (culture.Name == _currentCulture.Name)
+        {
+            foreach (var kvp in resources)
+            {
+                if (_observables.TryGetValue(kvp.Key, out var obs))
+                    obs.OnNext(kvp.Value);
+            }
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────
+
+    /// <summary>Current active culture.</summary>
+    public CultureInfo CurrentCulture => _currentCulture;
+
+    /// <summary>
+    /// Add resource strings for a culture from a flat dictionary.
+    /// Convenience overload that accepts a regular <see cref="Dictionary{TKey,TValue}"/>.
+    /// </summary>
+    public void AddResources(string cultureName, Dictionary<string, string> resources)
+    {
+        AddResources(new CultureInfo(cultureName), resources);
+    }
+
+    /// <summary>
+    /// Resolve a single key for the current culture (synchronous, non-observable access).
+    /// </summary>
+    public string? Resolve(string key)
+    {
+        var resolved = _resources.Resolve(_currentCulture);
+        return resolved.TryGetValue(key, out var val) ? val : null;
+    }
+}

--- a/src/Lingua/LinguaKey.cs
+++ b/src/Lingua/LinguaKey.cs
@@ -1,0 +1,19 @@
+namespace Irihi.Lingua;
+
+/// <summary>
+/// Strongly-typed key that pairs a resource key string with its owning manager.
+/// Used by <see cref="TranslateExtension"/> and generated <c>Keys</c> classes.
+/// </summary>
+public sealed class LinguaKey
+{
+    public string Key { get; }
+    public ILinguaManager Manager { get; }
+
+    public LinguaKey(string key, ILinguaManager manager)
+    {
+        Key = key;
+        Manager = manager;
+    }
+
+    public override string ToString() => Key;
+}

--- a/src/Lingua/LinguaManagerAttribute.cs
+++ b/src/Lingua/LinguaManagerAttribute.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Irihi.Lingua;
+
+/// <summary>
+/// Marks a partial class as a Lingua language manager.
+/// The resource path points to the base resource file (e.g. .resx or .json).
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public sealed class LinguaManagerAttribute : Attribute
+{
+    /// <summary>Path to the base resource file, relative to the project root.</summary>
+    public string ResourcePath { get; }
+
+    public LinguaManagerAttribute(string resourcePath)
+    {
+        ResourcePath = resourcePath;
+    }
+}

--- a/src/Lingua/LinguaObservableString.cs
+++ b/src/Lingua/LinguaObservableString.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+
+namespace Irihi.Lingua;
+
+/// <summary>
+/// A behaviour-subject style observable string that replays the latest value
+/// to new subscribers and pushes updates when the culture changes.
+/// </summary>
+public sealed class LinguaObservableString : IObservable<string?>
+{
+    private readonly List<IObserver<string?>> _observers = new();
+    private string? _currentValue;
+
+    public string Key { get; }
+    public string? CurrentValue => _currentValue;
+
+    public LinguaObservableString(string key, string? initialValue)
+    {
+        Key = key;
+        _currentValue = initialValue;
+    }
+
+    /// <summary>Push a new value to all active subscribers.</summary>
+    public void OnNext(string? value)
+    {
+        _currentValue = value;
+        // Snapshot to avoid mutation during iteration
+        var snapshot = _observers.ToArray();
+        foreach (var observer in snapshot)
+            observer.OnNext(value);
+    }
+
+    public IDisposable Subscribe(IObserver<string?> observer)
+    {
+        _observers.Add(observer);
+        // Replay current value to new subscriber (behaviour-subject semantics)
+        observer.OnNext(_currentValue);
+        return new Unsubscriber(_observers, observer);
+    }
+
+    private sealed class Unsubscriber : IDisposable
+    {
+        private readonly List<IObserver<string?>> _observers;
+        private readonly IObserver<string?> _observer;
+
+        public Unsubscriber(List<IObserver<string?>> observers, IObserver<string?> observer)
+        {
+            _observers = observers;
+            _observer = observer;
+        }
+
+        public void Dispose() => _observers.Remove(_observer);
+    }
+}

--- a/src/Lingua/LinguaRuntimeResources.cs
+++ b/src/Lingua/LinguaRuntimeResources.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Irihi.Lingua;
+
+/// <summary>
+/// Stores and resolves localized resources by culture, walking the culture
+/// hierarchy (zh-CN → zh → invariant) until a match is found.
+/// </summary>
+public sealed class LinguaRuntimeResources
+{
+    private readonly Dictionary<string, Dictionary<string, string>> _resources = new();
+    private readonly string _invariantCultureName;
+
+    public LinguaRuntimeResources(string invariantCultureName = "")
+    {
+        _invariantCultureName = invariantCultureName;
+    }
+
+    /// <summary>Register a full set of resource strings for a specific culture.</summary>
+    public void Add(CultureInfo culture, IReadOnlyDictionary<string, string> resources)
+    {
+        var key = culture.Name;
+        if (!_resources.TryGetValue(key, out var dict))
+            _resources[key] = dict = new Dictionary<string, string>();
+        foreach (var kvp in resources)
+            dict[kvp.Key] = kvp.Value;
+    }
+
+    /// <summary>
+    /// Resolve resources for the given culture, walking up the hierarchy
+    /// (culture → parent → parent … → invariant) and merging all keys.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Resolve(CultureInfo culture)
+    {
+        var result = new Dictionary<string, string>();
+
+        // Start from invariant (base), then overlay specific cultures
+        var chain = WalkCultureChain(culture);
+        for (var i = chain.Count - 1; i >= 0; i--)
+        {
+            if (_resources.TryGetValue(chain[i], out var dict))
+            {
+                foreach (var kvp in dict)
+                    result[kvp.Key] = kvp.Value;
+            }
+        }
+
+        return result;
+    }
+
+    private static List<string> WalkCultureChain(CultureInfo culture)
+    {
+        var chain = new List<string>();
+        var current = culture;
+        while (true)
+        {
+            chain.Add(current.Name);
+            if (current == CultureInfo.InvariantCulture || current.Parent == current)
+                break;
+            current = current.Parent;
+        }
+        return chain;
+    }
+}

--- a/src/Lingua/TranslateExtension.cs
+++ b/src/Lingua/TranslateExtension.cs
@@ -1,0 +1,81 @@
+using System;
+using global::Avalonia;
+using global::Avalonia.Data;
+using global::Avalonia.Markup.Xaml;
+
+namespace Irihi.Lingua;
+
+/// <summary>
+/// Avalonia markup extension that binds a <see cref="LinguaKey"/> to a target property.
+/// The binding auto-updates when the manager's culture changes.
+///
+/// Usage in XAML:
+/// <code>
+/// &lt;TextBlock Text="{Translate {x:Static local:LanguageManager+Keys.App_Title}}" /&gt;
+/// </code>
+/// </summary>
+public sealed class TranslateExtension : MarkupExtension
+{
+    public LinguaKey? Key { get; set; }
+
+    public TranslateExtension() { }
+
+    public TranslateExtension(LinguaKey key)
+    {
+        Key = key;
+    }
+
+    public override object ProvideValue(IServiceProvider serviceProvider)
+    {
+        if (Key == null)
+            return AvaloniaProperty.UnsetValue;
+
+        // Create an observable source that auto-updates on culture change
+        var observable = Key.Manager.GetObservable(Key.Key);
+        var source = new LinguaBindingSource(observable);
+
+        return new Binding
+        {
+            Source = source,
+            Path = "Value",
+            Mode = BindingMode.OneWay,
+        };
+    }
+}
+
+/// <summary>
+/// Lightweight binding source that exposes the latest value of an observable string
+/// as a CLR property, raising PropertyChanged on each update.
+/// </summary>
+internal sealed class LinguaBindingSource : System.ComponentModel.INotifyPropertyChanged
+{
+    private readonly IDisposable _subscription;
+    private string? _value;
+
+    public string? Value
+    {
+        get => _value;
+        private set
+        {
+            _value = value;
+            PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(Value)));
+        }
+    }
+
+    public LinguaBindingSource(IObservable<string?> observable)
+    {
+        _subscription = observable.Subscribe(
+            new AnonymousObserver<string?>(v => Value = v));
+    }
+
+    public event System.ComponentModel.PropertyChangedEventHandler? PropertyChanged;
+
+    private sealed class AnonymousObserver<T> : IObserver<T>
+    {
+        private readonly Action<T> _onNext;
+        public AnonymousObserver(Action<T> onNext) => _onNext = onNext;
+        public void OnNext(T value) => _onNext(value);
+        public void OnCompleted() { }
+        public void OnError(Exception error) { }
+    }
+}

--- a/src/Services/LocalizationService.cs
+++ b/src/Services/LocalizationService.cs
@@ -79,6 +79,27 @@ public class LocalizationService : INotifyPropertyChanged
     public string T(string key, params object[] args) => string.Format(this[key], args);
 
     /// <summary>
+    /// Return a copy of all strings for a given locale.
+    /// Used by <see cref="Irihi.Lingua.AppLanguageManager"/> to seed the Lingua resource store.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> GetAllStrings(string locale)
+    {
+        var result = new Dictionary<string, string>();
+
+        // Prefer cached (loaded from JSON), then fall back to built-in
+        if (_cache.TryGetValue(locale, out var cached))
+        {
+            foreach (var kvp in cached) result[kvp.Key] = kvp.Value;
+        }
+        else if (FallbackStrings.TryGetValue(locale, out var fb))
+        {
+            foreach (var kvp in fb) result[kvp.Key] = kvp.Value;
+        }
+
+        return result;
+    }
+
+    /// <summary>
     /// Load translations from embedded JSON files bundled as Avalonia resources.
     /// Called once at startup; idempotent.
     /// </summary>

--- a/src/ViewModels/MainWindowViewModel.cs
+++ b/src/ViewModels/MainWindowViewModel.cs
@@ -86,10 +86,17 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private void ToggleLocale()
     {
-        _loc.Locale = _loc.Locale == "zh-CN" ? "en-US" : "zh-CN";
+        var newLocale = _loc.Locale == "zh-CN" ? "en-US" : "zh-CN";
+
+        // Update legacy localization (triggers PropertyChanged → Lingua syncs via listener)
+        _loc.Locale = newLocale;
+
+        // Also update Lingua directly for reactive observable subscribers
+        Irihi.Lingua.AppLanguageManager.Instance.UpdateCulture(
+            new System.Globalization.CultureInfo(newLocale));
 
         // Persist
-        _config.Language = _loc.Locale;
+        _config.Language = newLocale;
         _ = ConfigServiceSingleton.Instance.SaveAsync();
     }
 

--- a/src/Views/MainWindow.axaml
+++ b/src/Views/MainWindow.axaml
@@ -2,10 +2,11 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:GeneralUpdate.Tools.ViewModels"
         xmlns:svc="using:GeneralUpdate.Tools.Services"
+        xmlns:lingua="using:Irihi.Lingua"
         x:Class="GeneralUpdate.Tools.Views.MainWindow"
         x:Name="MainWin"
         x:DataType="vm:MainWindowViewModel"
-        Title="{Binding Source={x:Static svc:LocalizationService.Instance}, Path=[App.Title]}"
+        Title="{Translate {x:Static lingua:AppLanguageManager+Keys.App_Title}}"
         Width="960" Height="640" MinWidth="780" MinHeight="540"
         WindowStartupLocation="CenterScreen">
 


### PR DESCRIPTION
## Summary

Closes #85

自实现完整的 Irihi.Lingua 公共 API，从源码级别集成到项目中，无需外部 NuGet 依赖。

### 问题背景

之前尝试通过 NuGet 集成 Irihi.Lingua 0.2.0 未成功：
1. 源码生成器在 IDE Debug 模式下导致启动挂起
2. Irihi.Lingua 与 Irihi.Ursa 之间存在命名空间冲突

### 实现方案

**核心 API（9 个新文件）** — 匹配 Lingua 0.2.0 全部公共接口：

| 类型 | 功能 |
|------|------|
| LinguaKey | Key + Manager 对，供 XAML 绑定 |
| ILinguaManager | UpdateCulture / GetObservable / AddResources |
| LinguaManagerAttribute | [LinguaManager] 标记属性 |
| LinguaObservableString | BehaviourSubject 风格可观察字符串 |
| LinguaRuntimeResources | 语言层次结构解析（zh-CN -> zh -> invariant） |
| LanguageManager | 抽象基类 |
| TranslateExtension | {Translate} XAML 标记扩展 |
| FormatTranslateExtension | {FormatTranslate} 格式化翻译扩展 |
| AppLanguageManager | 应用具体实现 + Keys 嵌套类 |

### 架构

```
AppLanguageManager (Lingua)  <->  LocalizationService (legacy)
       |                                    |
       | IObservable<string?>               | this["key"]
       v                                    v
  TranslateExtension (XAML)           Old Bindings (still work)
```

### 文件变更

- 9 new files: src/Lingua/*
- 4 modified: App.axaml.cs, MainWindowViewModel.cs, MainWindow.axaml, LocalizationService.cs
- +628 lines, -3 lines

### Build
dotnet build passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
